### PR TITLE
Added new inflow from boundary condition options

### DIFF
--- a/input_models/input/lamem_input.dat
+++ b/input_models/input/lamem_input.dat
@@ -225,12 +225,14 @@
 # Inflow velocity boundary condition
 
     bvel_face                 =         Left                         # Face identifier  (Left; Right; Front; Back; CompensatingInflow)
-    bvel_face_out             =         1                            # do we have outflow @ opposite boundary?
+    bvel_face_out             =         1                            # Velocity on opposite side: -1 for inverted velocity; 0 for no velocity; 1 for the same direction of velocity
     bvel_bot                  =        -20.0                         # bottom coordinate of inflow window
     bvel_top                  =        -10.0                         # top coordinate of inflow window
-    bvel_velin                =         1.0                          # inflow velocity
+	velin_num_periods         =         3                            # Number of periods when velocity changes (Optional)
+    velin_time_delims         =            2.0     5.0               # Change velocity at 2 and 5 Myrs (one less than number of intervals, not required for one interval) (Optional)
+    bvel_velin                =         1.0    0.0    -1.0           # inflow velocity for each time interval(Multiple values required if  velin_num_periods>1)
     bvel_velout               =         0.0                          # outflow velocity (if not specified, computed from mass balance)
-    bvel_relax_d              =         100                          # distance over which velocity is reduced
+    bvel_relax_d              =         100                          # vert.distance from bvel_bot and bvel_top over which velocity is reduced linearly
     bvel_velbot               =         0   	                     # bottom inflow velocity for use with bvel_face=CompensatingInflow
     bvel_veltop               =         0                            # top inflow velocity for use with bvel_face=CompensatingInflow
     bvel_temperature_inflow   =        Fixed_thermal_age             # Thermal age of the plate is constant

--- a/src/bc.cpp
+++ b/src/bc.cpp
@@ -518,6 +518,14 @@ PetscErrorCode BCCreate(BCCtx *bc, FB *fb)
         ierr = getScalarParam(fb, _REQUIRED_, "bvel_top",    &bc->top,    1, scal->length  ); CHKERRQ(ierr);
         ierr = getScalarParam(fb, _REQUIRED_, "bvel_velin",  &bc->velin,  1, scal->velocity); CHKERRQ(ierr);
         ierr = getScalarParam(fb, _OPTIONAL_, "bvel_velout", &bc->velout, 1, scal->velocity); CHKERRQ(ierr);
+		ierr = getIntParam   (fb, _OPTIONAL_, "velin_num_periods",  &bc->VelNumPeriods,  1,                  _max_periods_  ); CHKERRQ(ierr);
+		ierr = getScalarParam(fb, _OPTIONAL_, "bvel_relax_d",&bc->relax_dist,1, scal->length  ); CHKERRQ(ierr);
+		if(bc->VelNumPeriods>1)
+		{
+			ierr = getScalarParam(fb, _REQUIRED_, "velin_time_delims",   bc->VelTimeDelims,  bc->VelNumPeriods-1, scal->time    ); CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "bvel_velin",          bc->velin_array,    bc->VelNumPeriods,   scal->velocity); CHKERRQ(ierr);
+			ierr = BCGetVelins(bc); CHKERRQ(ierr);
+		}
         ierr = getScalarParam(fb, _OPTIONAL_, "bvel_phase_interval", bc->phase_interval, bc->num_phase_bc+1, scal->length); CHKERRQ(ierr);
         ierr = getStringParam(fb, _OPTIONAL_, "bvel_temperature_inflow", inflow_temp , NULL); 					CHKERRQ(ierr);
         if     	(!strcmp(inflow_temp, "Constant_T_inflow"))      bc->bvel_temperature_inflow = 1;
@@ -536,12 +544,6 @@ PetscErrorCode BCCreate(BCCtx *bc, FB *fb)
         ierr = getScalarParam(fb, _OPTIONAL_, "bvel_velbot", &bc->velbot, 1, scal->velocity); CHKERRQ(ierr);
         ierr = getScalarParam(fb, _OPTIONAL_, "bvel_veltop", &bc->veltop, 1, scal->velocity); CHKERRQ(ierr);
         
-
-        if(bc->face_out)
-        {
-            ierr = getScalarParam(fb, _REQUIRED_, "bvel_relax_d",&bc->relax_dist,1, scal->length  ); CHKERRQ(ierr);
-        }
-
         ierr = FDSTAGGetGlobalBox(bc->fs, NULL, NULL, &bz, NULL, NULL, NULL); CHKERRQ(ierr);
 
         // compute outflow velocity (if required)
@@ -772,6 +774,11 @@ PetscErrorCode BCCreate(BCCtx *bc, FB *fb)
 
     if (bc->face>0){
                             PetscPrintf(PETSC_COMM_WORLD, "   Adding inflow velocity at boundary         @ \n");
+							if(bc->VelNumPeriods>1)	
+							{
+							PetscPrintf(PETSC_COMM_WORLD, "      Number of inflow periods                : %d   \n", bc->VelNumPeriods);}
+							else {PetscPrintf(PETSC_COMM_WORLD, "      Number of inflow periods                : 1   \n");
+							}							
                             PetscPrintf(PETSC_COMM_WORLD, "      Inflow velocity boundary                : %s \n", str_inflow);
      if (bc->face_out==1){  PetscPrintf(PETSC_COMM_WORLD, "      Outflow at opposite boundary            @ \n");                    }
      if (bc->num_phase_bc>=0){     PetscPrintf(PETSC_COMM_WORLD, "      Inflow phase                            : %lld \n", (LLD)bc->phase);      }
@@ -1457,6 +1464,32 @@ PetscErrorCode BCApplyVelDefault(BCCtx *bc)
     PetscFunctionReturn(0);
 }
 //---------------------------------------------------------------------------
+PetscErrorCode BCGetVelins(
+		BCCtx       *bc)
+{
+	Scaling     *scal;
+	PetscScalar  bz;
+	PetscInt    jj;
+	PetscScalar time;
+	PetscErrorCode ierr;
+	PetscFunctionBegin;
+	// initialize
+	time = bc->ts->time;
+	scal = bc->scal;
+	if(bc->VelNumPeriods)
+	{
+		for(jj = 0; jj < bc->VelNumPeriods-1; jj++)
+		{
+			if(time*scal->time < bc->VelTimeDelims[jj]*scal->time) break;
+		}
+		ierr = FDSTAGGetGlobalBox(bc->fs, NULL, NULL, &bz, NULL, NULL, NULL); CHKERRQ(ierr);
+		bc->velin  =  bc->velin_array[jj];
+		bc->velout = -bc->velin*(bc->top - bc->bot)/(bc->bot - bz);
+	}
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
 PetscErrorCode BCApplyVelTPC(BCCtx *bc)
 {
     // apply two-point constraints on the boundaries
@@ -1706,7 +1739,10 @@ PetscErrorCode BCApplyBoundVel(BCCtx *bc)
 
     // check whether constraint is activated
     if(!bc->face) PetscFunctionReturn(0);
-
+	
+	// update inflow velocity value for current timestep
+	ierr = BCGetVelins(bc); CHKERRQ(ierr);
+	
     // access context
     fs     = bc->fs;
     bot    = bc->bot;
@@ -1748,12 +1784,24 @@ PetscErrorCode BCApplyBoundVel(BCCtx *bc)
             vel = 0.0;
             if(bc->face_out)
             {
-                if(z <= top && z >= bot) vel = velin;
+                if(z <= top && z >= bot)           vel = velin;
                 if(z >= top && z<= top+relax_dist) vel = velin-(velin/(relax_dist))*(z-top);
                 if(z <= bot && z>= bot-relax_dist) vel = velin+(velin/(relax_dist))*(z-bot);
+				if(bc->face_out != 1) {
+					if(z < bot-relax_dist)             vel = velout;
+				}
 
-                if(i == 0 )    { bcvx[k][j][i] = vel; }
-                if(i == mnx)   { bcvx[k][j][i] = vel; }
+		        if((bc->face  == 1) && i == 0)                         { bcvx[k][j][i] =  vel; }
+                if((bc->face  == 1) && i == mnx && bc->face_out == 1)  { bcvx[k][j][i] =  vel; }
+
+		        if((bc->face  == 2) && i == 0   && bc->face_out == 1)  { bcvx[k][j][i] = -vel; }
+		        if((bc->face  == 2) && i == mnx)                       { bcvx[k][j][i] = -vel; }
+
+		        if((bc->face  == 1) && i == 0   && bc->face_out == -1) { bcvx[k][j][i] =  vel; }
+		        if((bc->face  == 1) && i == mnx && bc->face_out == -1) { bcvx[k][j][i] = -vel; }
+
+		        if((bc->face  == 2) && i == 0   && bc->face_out == -1) { bcvx[k][j][i] =  vel; }
+		        if((bc->face  == 2) && i == mnx && bc->face_out == -1) { bcvx[k][j][i] = -vel; }
 
 
             }
@@ -1804,10 +1852,22 @@ PetscErrorCode BCApplyBoundVel(BCCtx *bc)
                 if(z <= top && z >= bot) vel = velin;
                 if(z >= top && z<= top+relax_dist) vel = velin-(velin/(relax_dist))*(z-top);
                 if(z <= bot && z>= bot-relax_dist) vel = velin+(velin/(relax_dist))*(z-bot);
+				if(bc->face_out != 1) {
+					if(z < bot-relax_dist)             vel = velout;
+				}
+
+		        if((bc->face  == 3) && j == 0)                         { bcvy[k][j][i] =  vel; }
+                if((bc->face  == 3) && j == mny && bc->face_out == 1)  { bcvy[k][j][i] =  vel; }
+
+		        if((bc->face  == 4) && j == 0   && bc->face_out == 1)  { bcvy[k][j][i] = -vel; }
+		        if((bc->face  == 4) && j == mny)                       { bcvy[k][j][i] = -vel; }
 
 
-                if(j == 0 )   { bcvy[k][j][i] = vel; }
-                if(j == mny)  { bcvy[k][j][i] = vel; }
+		        if((bc->face  == 3) && j == 0   && bc->face_out == -1) { bcvy[k][j][i] =  vel; }
+		        if((bc->face  == 3) && j == mny && bc->face_out == -1) { bcvy[k][j][i] = -vel; }
+
+		        if((bc->face  == 4) && j == 0   && bc->face_out == -1) { bcvy[k][j][i] =  vel; }
+		        if((bc->face  == 4) && j == mny && bc->face_out == -1) { bcvy[k][j][i] = -vel; }
             }
             else
             {

--- a/src/bc.h
+++ b/src/bc.h
@@ -265,6 +265,9 @@ struct BCCtx
 	PetscInt     bvel_temperature_inflow;
 	PetscScalar  bvel_thermal_age,bvel_potential_temperature, bvel_temperature_top;
 	PetscScalar  bvel_constant_temperature;
+	PetscInt     VelNumPeriods; 			// number of periods when boundary inflow velocity will change , must be less than _max_periods_
+    PetscScalar  VelTimeDelims [_max_periods_-1];
+    PetscScalar  velin_array [_max_periods_];
 
 	// Plume inflow bottom boundary condition
 	PetscInt        Plume_Inflow;
@@ -418,6 +421,9 @@ PetscErrorCode BCGetBGStrainRates(
 		PetscScalar *Rxx_,
 		PetscScalar *Ryy_,
 		PetscScalar *Rzz_);
+//change velin in accordance with given time intervals
+PetscErrorCode BCGetVelins(
+		BCCtx       *bc);
 
 // Get current bottom temperature
 PetscErrorCode BCGetTempBound(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -912,5 +912,20 @@ end
                             keywords=keywords, accuracy=acc, cores=4, opt=true)
 end
 
+@testset "t32_BC_velocity" begin
+    dir = "t32_BC_velocity";
+    
+    keywords = ("|Div|_inf","|Div|_2","|mRes|_2")
+    acc      = ((rtol=1e-7,atol=1e-11), (rtol=1e-5, atol=1e-11), (rtol=2e-4,atol=1e-10));
+
+   # Test if boundaries are pushed from front and back inside the model:
+    @test perform_lamem_test(dir,"BC_velocity_2D_FB.dat","BC_velocity_2D_FB_opt-p1.expected",
+                            keywords=keywords, accuracy=acc, cores=1, opt=true)
+
+    # Test if boundaries are pushed from left to right and then from right to left:
+    @test perform_lamem_test(dir,"BC_velocity_2D_LR.dat","BC_velocity_2D_LR_opt-p1.expected",
+                            keywords=keywords, accuracy=acc, cores=1, opt=true)
+end
+
 end
 

--- a/test/t32_BC_velocity/BC_velocity_2D_FB.dat
+++ b/test/t32_BC_velocity/BC_velocity_2D_FB.dat
@@ -1,0 +1,297 @@
+# This is an example of variable inflow velocity from left boundary with prescribed time intervals for each stage
+# The model has a viscoelastoplastic rheology and the geometry is created with the build-in 
+# geometry objects. We use a multigrid solver
+
+#===============================================================================
+# Scaling
+#===============================================================================
+
+	units            = geo		# geological units 
+	
+	unit_temperature = 1000
+	unit_length      = 1e3
+	unit_viscosity   = 1e19
+	unit_stress      = 1e9
+	
+#===============================================================================
+# Time stepping parameters
+#===============================================================================
+
+	time_end  = 100     # simulation end time
+	dt        = 0.001   # initial time step
+	dt_min    = 1e-5    # minimum time step (declare divergence if lower value is attempted)
+	dt_max    = 0.1   	# maximum time step
+	inc_dt    = 0.2     # time step increment per time step (fraction of unit)
+	CFL       = 0.5     # CFL (Courant-Friedrichs-Lewy) criterion
+	CFLMAX    = 1.0     # CFL criterion for elasticity
+	nstep_max = 70      # maximum allowed number of steps (lower bound: time_end/dt_max)
+	nstep_out = 5       # save output every n steps
+	nstep_rdb = 100     # save restart database every n steps
+
+
+#===============================================================================
+# Grid & discretization parameters
+#===============================================================================
+
+# Number of cells for all segments
+	nel_x = 1
+	nel_y = 32
+	nel_z = 16
+
+# Coordinates of all segments (including start and end points)
+
+	coord_x = -2.5  2.5
+	coord_y = -100  100
+	coord_z = -100  100
+
+#===============================================================================
+# Free surface
+#===============================================================================
+	surf_use           = 1                # free surface activation flag
+	surf_corr_phase    = 1                # air phase ratio correction flag (due to surface position)
+	surf_level         = 0                # initial level
+	surf_air_phase     = 0                # phase ID of sticky air layer
+	surf_max_angle     = 45.0             # maximum angle with horizon (smoothed if larger)
+	
+#===============================================================================
+# Boundary conditions
+#===============================================================================
+	open_top_bound = 1
+
+	# Velocity boundary condition
+
+	bvel_face               = Front              # # Face identifier  (Left; Right; Front; Back; CompensatingInflow)
+    bvel_face_out           = -1
+	bvel_bot                = -30               # bottom coordinate of inflow window
+	bvel_top                = 0                 # top coordinate of inflow window
+    velin_num_periods       = 3                 # number of intervals for inflow velocity
+	velin_time_delims       =    0.1   0.6      # time delimiters (one less than number of intervals, not required for one interval)
+	bvel_velin              = 10    -10   10    # strain rates for each interval
+	bvel_relax_d            = 10
+
+
+# temperature on the top & bottom boundaries
+
+	temp_top  = 0.0
+	temp_bot  = 1300.0
+
+#===============================================================================
+# Solution parameters & controls
+#===============================================================================
+
+	gravity        = 0.0 0.0 -9.81  # gravity vector
+	FSSA           = 1.0            # free surface stabilization parameter [0 - 1]
+	init_guess     = 1              # initial guess flag
+	p_lim_plast    = 1              # limit pressure at first iteration for plasticity
+#	p_litho_visc   = 1              # use lithostatic pressure for creep laws
+	p_litho_plast  = 1              # use lithostatic pressure for plasticity
+	eta_min        = 1e19           # viscosity upper bound
+	eta_max        = 1e25           # viscosity lower limit
+	eta_ref        = 1e22           # reference viscosity (initial guess)
+	min_cohes      = 1e6            # cohesion lower bound
+	min_fric       = 1.0            # friction lower bound
+	tau_ult        = 1e9            # ultimate yield stress
+
+	
+#===============================================================================
+# Solver options
+#===============================================================================
+	SolverType 		=	direct 			# solver [direct or multigrid]
+	DirectSolver 	=	mumps			# mumps/superlu_dist/pastix	
+	DirectPenalty 	=	1e5
+		
+#===============================================================================
+# Model setup & advection
+#===============================================================================
+
+	msetup         = geom              # setup type
+	nmark_x        = 3                 # markers per cell in x-direction
+	nmark_y        = 3                 # ...                 y-direction
+	nmark_z        = 3                 # ...                 z-direction
+	bg_phase       = 0                 # background phase ID
+	rand_noise     = 1                 # random noise flag
+	advect         = rk2               # advection scheme
+	interp         = minmod             # velocity interpolation scheme
+	mark_ctrl      = basic             # marker control type
+	nmark_lim      = 8 100            # min/max number per cell
+	
+
+# Geometric primitives:
+	
+	# sticky air
+	<BoxStart>
+		phase  = 0
+		bounds =  -2.5 2.5 -100 100 0 100  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+	
+	# Asthenosphere
+	<BoxStart>
+		phase  = 1
+		bounds =  -2.5 2.5 -100 100 -100 0  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+	
+	# Lithosphere left
+	<BoxStart>
+		phase  = 2
+		bounds =  -2.5 2.5 -100 -20 -30 0  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+
+	# lithosphere right
+	<BoxStart>
+		phase  = 2
+		bounds =  -2.5 2.5 20 100 -30 0  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+	
+#===============================================================================
+# Output
+#===============================================================================
+
+# Grid output options (output is always active)
+
+	out_file_name       = BC_velocity_FB # output file name
+	out_pvd             = 1       	# activate writing .pvd file
+	out_phase           = 1
+	out_density         = 1
+	out_visc_total      = 1
+	out_visc_creep      = 1
+	out_velocity        = 1
+	out_pressure        = 1
+	out_eff_press       = 1
+	out_temperature     = 1
+	out_dev_stress      = 1
+	out_j2_dev_stress   = 1
+	out_strain_rate     = 1
+	out_j2_strain_rate  = 1
+	out_yield           = 1
+	out_plast_strain    = 1
+	out_plast_dissip    = 1
+	out_tot_displ       = 1
+	out_moment_res      = 1
+	out_cont_res        = 1
+	
+# AVD phase viewer output options (requires activation)
+
+	out_avd     		= 1 # activate AVD phase output
+	out_avd_pvd 		= 1 # activate writing .pvd file
+	out_avd_ref 		= 3 # AVD grid refinement factor
+	
+# Free surface output options (can be activated only if surface tracking is enabled)
+
+	out_surf            = 1 # activate surface output
+	out_surf_pvd        = 1 # activate writing .pvd file
+	out_surf_velocity   = 1
+	out_surf_topography = 1
+	out_surf_amplitude  = 1
+	
+#===============================================================================
+# Material phase parameters
+#===============================================================================
+	# Strain softening parameters
+	<SofteningStart>
+		ID   = 0
+		A    = 0.87		# reduction ratio = 1-FinalParameter/InitialParameter
+		APS1 = 0.5
+		APS2 = 1.5
+	<SofteningEnd>
+	
+	# Sticky Air
+	<MaterialStart>
+		ID  = 0 	# phase id
+		rho = 0 	# density
+		G   = 5e10
+		eta = 1e18 	# viscosity
+		
+		ch  		=  20e6	  # Cohesion
+		fr  		=  15	  # initial friction angle
+	<MaterialEnd>
+
+	# Asthenosphere
+	<MaterialStart>
+		ID  		= 	1       # phase id
+		rho 		= 	3300    # density
+		eta 		= 	1e20    # viscosity
+		G   		= 	5e10
+
+		ch  		=  	20e5	  # Cohesion
+		fr  		=  	15	  # initial friction angle
+		frSoftID   	=  	0     # softening ID
+	<MaterialEnd>
+
+	# Lithosphere
+	<MaterialStart>
+		ID  		= 	2       # phase id
+		rho 		= 	3250    # density
+		eta 		= 	1e21    # viscosity
+		G   		= 	5e10
+		
+		ch  		=  	20e5	  # Cohesion
+		fr  		=  	15	  # initial friction angle
+		frSoftID   	=  	0     # softening ID
+	<MaterialEnd>
+	
+	# Lower Lithosphere
+	<MaterialStart>
+		ID  		= 	3       # phase id
+		rho 		= 	3300    # density
+		eta 		= 	1e20    # viscosity		1e22: symmetric, 1e21: asymmetric
+		G   		= 	5e10
+
+	<MaterialEnd>
+	
+#===============================================================================
+# PETSc options
+#===============================================================================
+
+<PetscOptionsStart>
+
+	# LINEAR & NONLINEAR SOLVER OPTIONS
+	-snes_ksp_ew
+	-snes_ksp_ew_rtolmax 1e-3
+	-snes_rtol 1e-3					
+	-snes_atol 1e-3					# following Le Pourhiet et al. (EPSL, 2017)
+	-snes_max_it 20					
+	
+
+	-snes_PicardSwitchToNewton_rtol 1e-3   # relative tolerance to switch to Newton (1e-2)
+	-snes_NewtonSwitchToPicard_it  	10     # number of Newton iterations after which we switch back to Picard
+
+# Jacobian solver
+
+	-js_ksp_max_it 20
+
+#	-js_ksp_monitor # display how the inner iterations converge
+
+         -da_refine_x 1
+#   -gmg_pc_view
+#   -gmg_dump
+#	-gmg_pc_type mg 
+#	-gmg_pc_mg_levels 2 
+#	-gmg_pc_mg_galerkin
+#	-gmg_pc_mg_type multiplicative
+#	-gmg_pc_mg_cycle_type v
+#
+#	-gmg_mg_levels_ksp_type richardson
+#	-gmg_mg_levels_ksp_richardson_scale 0.5
+#	-gmg_mg_levels_ksp_max_it 5
+#	-gmg_mg_levels_pc_type jacobi
+
+	-gmg_pc_type mg 
+	-gmg_pc_mg_levels 1
+	-gmg_pc_mg_galerkin
+	-gmg_pc_mg_type multiplicative
+	-gmg_pc_mg_cycle_type v
+#
+	-gmg_mg_levels_ksp_type richardson
+	-gmg_mg_levels_ksp_richardson_scale 0.5
+	-gmg_mg_levels_ksp_max_it 4
+	-gmg_mg_levels_pc_type jacobi
+#
+
+
+	-crs_ksp_type preonly
+	-crs_pc_type lu
+	-crs_pc_factor_mat_solver_package superlu_dist
+
+<PetscOptionsEnd>
+
+#===============================================================================

--- a/test/t32_BC_velocity/BC_velocity_2D_FB_opt-p1.expected
+++ b/test/t32_BC_velocity/BC_velocity_2D_FB_opt-p1.expected
@@ -1,0 +1,2266 @@
+-------------------------------------------------------------------------- 
+                   Lithosphere and Mantle Evolution Model                   
+     Compiled: Date: May 17 2023 - Time: 10:57:24 	    
+     Version : 2.1.0 
+-------------------------------------------------------------------------- 
+        STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
+-------------------------------------------------------------------------- 
+Parsing input file : BC_velocity_2D_FB.dat 
+   Adding PETSc option: -snes_ksp_ew
+   Adding PETSc option: -snes_ksp_ew_rtolmax 1e-3
+   Adding PETSc option: -snes_rtol 1e-3
+   Adding PETSc option: -snes_atol 1e-3
+   Adding PETSc option: -snes_max_it 20
+   Adding PETSc option: -snes_PicardSwitchToNewton_rtol 1e-3
+   Adding PETSc option: -snes_NewtonSwitchToPicard_it 10
+   Adding PETSc option: -js_ksp_max_it 20
+   Adding PETSc option: -da_refine_x 1
+   Adding PETSc option: -gmg_pc_type mg
+   Adding PETSc option: -gmg_pc_mg_levels 1
+   Adding PETSc option: -gmg_pc_mg_galerkin
+   Adding PETSc option: -gmg_pc_mg_type multiplicative
+   Adding PETSc option: -gmg_pc_mg_cycle_type v
+   Adding PETSc option: -gmg_mg_levels_ksp_type richardson
+   Adding PETSc option: -gmg_mg_levels_ksp_richardson_scale 0.5
+   Adding PETSc option: -gmg_mg_levels_ksp_max_it 4
+   Adding PETSc option: -gmg_mg_levels_pc_type jacobi
+   Adding PETSc option: -crs_ksp_type preonly
+   Adding PETSc option: -crs_pc_type lu
+   Adding PETSc option: -crs_pc_factor_mat_solver_package superlu_dist
+Finished parsing input file : BC_velocity_2D_FB.dat 
+--------------------------------------------------------------------------
+Scaling parameters:
+   Temperature : 1000. [C/K] 
+   Length      : 1000. [m] 
+   Viscosity   : 1e+19 [Pa*s] 
+   Stress      : 1e+09 [Pa] 
+--------------------------------------------------------------------------
+Time stepping parameters:
+   Simulation end time          : 100. [Myr] 
+   Maximum number of steps      : 70 
+   Time step                    : 0.001 [Myr] 
+   Minimum time step            : 1e-05 [Myr] 
+   Maximum time step            : 0.1 [Myr] 
+   Time step increase factor    : 0.2 
+   CFL criterion                : 0.5 
+   CFLMAX (fixed time steps)    : 1. 
+   Output every [n] steps       : 5 
+   Output [n] initial steps     : 1 
+   Save restart every [n] steps : 100 
+--------------------------------------------------------------------------
+Grid parameters:
+   Total number of cpu                  : 1 
+   Processor grid  [nx, ny, nz]         : [1, 1, 1]
+   Fine grid cells [nx, ny, nz]         : [1, 32, 16]
+   Number of cells                      :  512
+   Number of faces                      :  2096
+   Maximum cell aspect ratio            :  2.50000
+   Lower coordinate bounds [bx, by, bz] : [-2.5, -100., -100.]
+   Upper coordinate bounds [ex, ey, ez] : [2.5, 100., 100.]
+--------------------------------------------------------------------------
+Softening laws: 
+--------------------------------------------------------------------------
+   SoftLaw [0] : A = 0.87, APS1 = 0.5, APS2 = 1.5
+--------------------------------------------------------------------------
+Material parameters: 
+--------------------------------------------------------------------------
+- Melt factor mfc = 0.000000   Phase ID : 0   
+   (elast)  : G = 5e+10 [Pa]  
+   (diff)   : eta = 1e+18 [Pa*s]  Bd = 5e-19 [1/Pa/s]  
+   (plast)  : ch = 2e+07 [Pa]  fr = 15. [deg]  
+
+- Melt factor mfc = 0.000000   Phase ID : 1   
+   (dens)   : rho = 3300. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Vs = 3892.49 [m/s]  
+   (diff)   : eta = 1e+20 [Pa*s]  Bd = 5e-21 [1/Pa/s]  
+   (plast)  : ch = 2e+06 [Pa]  fr = 15. [deg]  frSoftID = 0 
+
+- Melt factor mfc = 0.000000   Phase ID : 2   
+   (dens)   : rho = 3250. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Vs = 3922.32 [m/s]  
+   (diff)   : eta = 1e+21 [Pa*s]  Bd = 5e-22 [1/Pa/s]  
+   (plast)  : ch = 2e+06 [Pa]  fr = 15. [deg]  frSoftID = 0 
+
+- Melt factor mfc = 0.000000   Phase ID : 3   
+   (dens)   : rho = 3300. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Vs = 3892.49 [m/s]  
+   (diff)   : eta = 1e+20 [Pa*s]  Bd = 5e-21 [1/Pa/s]  
+
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Free surface parameters: 
+   Sticky air phase ID       : 0 
+   Initial surface level     : 0. [km] 
+   Erosion model             : none
+   Sedimentation model       : none
+   Correct marker phases     @ 
+   Maximum surface slope     : 45. [deg]
+--------------------------------------------------------------------------
+Boundary condition parameters: 
+   No-slip boundary mask [lt rt ft bk bm tp]  : 0 0 0 0 0 0 
+   Open top boundary                          @ 
+   Top boundary temperature                   : 0. [C] 
+   Bottom boundary temperature                : 1300. [C] 
+   Adding inflow velocity at boundary         @ 
+      Inflow velocity boundary                : Front 
+      Inflow phase from next to boundary      @ 
+      Inflow window [bottom, top]             : [-30.00,0.00] [km] 
+      Inflow velocity                         : 10.00 [cm/yr] 
+      Velocity smoothening distance           : 10.00 [km] 
+      Inflow temperature from closest marker  @ 
+--------------------------------------------------------------------------
+Solution parameters & controls:
+   Gravity [gx, gy, gz]                    : [0., 0., -9.81] [m/s^2] 
+   Surface stabilization (FSSA)            :  1. 
+   Compute initial guess                   @ 
+   Use lithostatic pressure for creep      @ 
+   Use lithostatic pressure for plasticity @ 
+   Limit pressure at first iteration       @ 
+   Minimum viscosity                       : 1e+19 [Pa*s] 
+   Maximum viscosity                       : 1e+25 [Pa*s] 
+   Reference viscosity (initial guess)     : 1e+22 [Pa*s] 
+   Minimum cohesion                        : 1e+06 [Pa] 
+   Minimum friction                        : 1. [deg] 
+   Ultimate yield stress                   : 1e+09 [Pa] 
+   Max. melt fraction (viscosity, density) : 0.15    
+   Rheology iteration number               : 25    
+   Rheology iteration tolerance            : 1e-06    
+   Ground water level type                 : none 
+--------------------------------------------------------------------------
+Advection parameters:
+   Advection scheme              : Runge-Kutta 2-nd order
+   Periodic marker advection     : 0 0 0 
+   Marker setup scheme           : geometric primitives
+   Velocity interpolation scheme : MINMOD (correction + MINMOD)
+   Marker control type           : AVD for cells + corner insertion
+   Markers per cell [nx, ny, nz] : [3, 3, 3] 
+   Marker distribution type      : random noise
+   Background phase ID           : 0 
+--------------------------------------------------------------------------
+Reading geometric primitives ... done (0.00030844 sec)
+--------------------------------------------------------------------------
+Output parameters:
+   Output file name                        : BC_velocity_FB 
+   Write .pvd file                         : yes 
+   Phase                                   @ 
+   Density                                 @ 
+   Total effective viscosity               @ 
+   Creep effective viscosity               @ 
+   Velocity                                @ 
+   Pressure                                @ 
+   Temperature                             @ 
+   Deviatoric stress tensor                @ 
+   Deviatoric stress second invariant      @ 
+   Deviatoric strain rate tensor           @ 
+   Deviatoric strain rate second invariant @ 
+   Yield stress                            @ 
+   Accumulated Plastic Strain (APS)        @ 
+   Plastic dissipation                     @ 
+   Total displacements                     @ 
+   Momentum residual                       @ 
+   Continuity residual                     @ 
+--------------------------------------------------------------------------
+Surface output parameters:
+   Write .pvd file : yes 
+   Velocity        @ 
+   Topography      @ 
+   Amplitude       @ 
+--------------------------------------------------------------------------
+AVD output parameters:
+   Write .pvd file       : yes 
+   AVD refinement factor : 3 
+--------------------------------------------------------------------------
+Preconditioner parameters: 
+   Matrix type                   : monolithic
+   Penalty parameter (pgamma)    : 1.000000e+05
+   Preconditioner type           : user-defined
+--------------------------------------------------------------------------
+Solver parameters specified: 
+   Outermost Krylov solver       : gmres 
+   Solver type                   : serial direct/lu 
+   Solver package                : petsc 
+--------------------------------------------------------------------------
+============================== INITIAL GUESS =============================
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.048300213426e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.089691232988e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.010008 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.681579449672e-08 
+      |Div|_2   = 3.388733722660e-07 
+   Momentum: 
+      |mRes|_2  = 4.089550834695e-05 
+--------------------------------------------------------------------------
+Saving output ... done (0.010237 sec)
+--------------------------------------------------------------------------
+================================= STEP 1 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00000000 [Myr] 
+Tentative time step : 0.00100000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.445630455644e-01 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.159826679514e-03 
+  1 PICARD ||F||/||F0||=9.475169e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 2.139909492928e-03 
+  2 PICARD ||F||/||F0||=3.929590e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 2.013658323833e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0144435 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.663285159587e-09 
+      |Div|_2   = 3.306881627139e-09 
+   Momentum: 
+      |mRes|_2  = 2.013658323562e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00100 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 1 markers in 7.4901e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00941441 sec)
+--------------------------------------------------------------------------
+================================= STEP 2 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00100000 [Myr] 
+Tentative time step : 0.00120000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.317290318894e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.010074396719e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00572228 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.651192375740e-09 
+      |Div|_2   = 3.428291035043e-08 
+   Momentum: 
+      |mRes|_2  = 5.010074384990e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00120 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 3 markers in 7.5186e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 3 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00220000 [Myr] 
+Tentative time step : 0.00144000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.460187553338e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.760094962766e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00564413 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.043767130678e-09 
+      |Div|_2   = 1.404678453851e-08 
+   Momentum: 
+      |mRes|_2  = 3.760094960142e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00144 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 1 markers in 7.3784e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 4 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00364000 [Myr] 
+Tentative time step : 0.00172800 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.171493824815e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.138908328988e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0056215 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.321538740032e-09 
+      |Div|_2   = 9.466642520389e-09 
+   Momentum: 
+      |mRes|_2  = 2.138908326893e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00173 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 3 markers in 7.7538e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 5 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00536800 [Myr] 
+Tentative time step : 0.00207360 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 9.711060945101e-04 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.407681405627e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00563399 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.616788482358e-09 
+      |Div|_2   = 9.810670022925e-09 
+   Momentum: 
+      |mRes|_2  = 1.407681402208e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00207 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 3 markers in 7.4852e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00997787 sec)
+--------------------------------------------------------------------------
+================================= STEP 6 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00744160 [Myr] 
+Tentative time step : 0.00248832 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.848671485337e-04 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.590447427776e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00575607 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.992252766601e-09 
+      |Div|_2   = 1.112158538208e-08 
+   Momentum: 
+      |mRes|_2  = 1.590447423888e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00249 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 4 markers in 7.6993e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 7 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00992992 [Myr] 
+Tentative time step : 0.00298598 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.152696198483e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.316084635682e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00562912 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.086769031879e-08 
+      |Div|_2   = 2.160827752098e-08 
+   Momentum: 
+      |mRes|_2  = 1.316084617943e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00299 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 8 markers in 7.7173e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 8 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01291590 [Myr] 
+Tentative time step : 0.00358318 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.677889457935e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.864649433030e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0056629 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.316824907632e-08 
+      |Div|_2   = 3.477348194124e-08 
+   Momentum: 
+      |mRes|_2  = 1.864649400606e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00358 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 7 markers in 8.0502e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 9 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01649908 [Myr] 
+Tentative time step : 0.00429982 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.658335723403e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.974232589173e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00560695 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.888326315197e-08 
+      |Div|_2   = 4.687229206607e-08 
+   Momentum: 
+      |mRes|_2  = 2.974232552239e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00430 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 13 markers in 7.8748e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 10 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02079890 [Myr] 
+Tentative time step : 0.00515978 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.401315604181e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.650856951218e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00559672 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.355402489116e-08 
+      |Div|_2   = 3.134521424348e-08 
+   Momentum: 
+      |mRes|_2  = 4.650856940655e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00516 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 8 markers in 7.7758e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0106076 sec)
+--------------------------------------------------------------------------
+================================ STEP 11 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02595868 [Myr] 
+Tentative time step : 0.00619174 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.843017777374e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.990007184513e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00571564 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.951614599423e-09 
+      |Div|_2   = 3.162340043884e-08 
+   Momentum: 
+      |mRes|_2  = 2.990007167790e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00619 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 18 markers in 8.1090e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 12 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03215042 [Myr] 
+Tentative time step : 0.00743008 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.186733106344e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.941437101246e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00564555 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.921187175883e-08 
+      |Div|_2   = 4.406264426816e-08 
+   Momentum: 
+      |mRes|_2  = 4.941437081601e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00743 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 16 markers in 8.0286e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 13 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03958050 [Myr] 
+Tentative time step : 0.00891610 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.078580072026e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.707743083489e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00564186 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.927796493115e-08 
+      |Div|_2   = 9.145973898036e-08 
+   Momentum: 
+      |mRes|_2  = 9.707743040405e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00892 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 16 markers in 8.0038e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 14 =================================
+--------------------------------------------------------------------------
+Current time        : 0.04849660 [Myr] 
+Tentative time step : 0.01069932 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.840333302372e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.052934143181e-03 
+  1 PICARD ||F||/||F0||=3.707080e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 4.774625901871e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0102573 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.466008694661e-10 
+      |Div|_2   = 2.109417167162e-09 
+   Momentum: 
+      |mRes|_2  = 4.774625901824e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01070 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 23 markers in 8.1265e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 15 =================================
+--------------------------------------------------------------------------
+Current time        : 0.05919592 [Myr] 
+Tentative time step : 0.01283918 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.212753395487e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.114419455669e-03 
+  1 PICARD ||F||/||F0||=3.468736e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 4.647106569701e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0099889 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.450422870567e-09 
+      |Div|_2   = 2.815799243102e-09 
+   Momentum: 
+      |mRes|_2  = 4.647106569616e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01284 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 22 markers in 8.0814e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0113595 sec)
+--------------------------------------------------------------------------
+================================ STEP 16 =================================
+--------------------------------------------------------------------------
+Current time        : 0.07203511 [Myr] 
+Tentative time step : 0.01540702 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.336866608213e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.958897416119e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00571865 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.402713927120e-08 
+      |Div|_2   = 1.164482388709e-07 
+   Momentum: 
+      |mRes|_2  = 9.958897348038e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01541 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 25 markers in 8.6027e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 17 =================================
+--------------------------------------------------------------------------
+Current time        : 0.08744213 [Myr] 
+Tentative time step : 0.01848843 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.037356154704e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.631059623877e-03 
+  1 PICARD ||F||/||F0||=4.357967e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 9.774087785391e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0100139 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.736986548225e-09 
+      |Div|_2   = 6.403359836742e-09 
+   Momentum: 
+      |mRes|_2  = 9.774087785182e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01849 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 26 markers in 8.2176e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 18 =================================
+--------------------------------------------------------------------------
+Current time        : 0.10593056 [Myr] 
+Tentative time step : 0.02218611 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 9.973852252574e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.012419894759e-02 
+  1 PICARD ||F||/||F0||=4.022939e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 4.784336190092e-03 
+  2 PICARD ||F||/||F0||=4.796879e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 1.773669275452e-03 
+  3 PICARD ||F||/||F0||=1.778319e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  4 SNES Function norm 8.812807365151e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 4
+SNES solution time      : 0.018765 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.081341766346e-09 
+      |Div|_2   = 2.550005341676e-09 
+   Momentum: 
+      |mRes|_2  = 8.812807365114e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.02219 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 6 markers in 7.8056e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 19 =================================
+--------------------------------------------------------------------------
+Current time        : 0.12811667 [Myr] 
+Tentative time step : 0.02662333 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 9.905385405598e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.942052988805e-03 
+  1 PICARD ||F||/||F0||=2.970155e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.660214367087e-03 
+  2 PICARD ||F||/||F0||=1.676072e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 8.936085958090e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0143227 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.167264552837e-09 
+      |Div|_2   = 2.132498205870e-09 
+   Momentum: 
+      |mRes|_2  = 8.936085958064e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.02662 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 16 markers in 7.9854e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 20 =================================
+--------------------------------------------------------------------------
+Current time        : 0.15474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.001968321871e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.671767844555e-03 
+  1 PICARD ||F||/||F0||=5.243908e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.322538872872e-03 
+  2 PICARD ||F||/||F0||=1.888810e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 7.345288705715e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0145349 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.444217312434e-09 
+      |Div|_2   = 3.608043286326e-09 
+   Momentum: 
+      |mRes|_2  = 7.345288705626e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 42 markers in 8.3681e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0106129 sec)
+--------------------------------------------------------------------------
+================================ STEP 21 =================================
+--------------------------------------------------------------------------
+Current time        : 0.18599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.874919510379e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.230071070659e-03 
+  1 PICARD ||F||/||F0||=2.093767e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 5.842284446013e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.010253 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.193596434531e-09 
+      |Div|_2   = 4.217866393866e-09 
+   Momentum: 
+      |mRes|_2  = 5.842284445861e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 25 markers in 8.1121e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 22 =================================
+--------------------------------------------------------------------------
+Current time        : 0.21724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.034100425970e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.499677465580e-03 
+  1 PICARD ||F||/||F0||=4.975302e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.292874233547e-03 
+  2 PICARD ||F||/||F0||=1.838009e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 4.975978433896e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0143403 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.618351684435e-10 
+      |Div|_2   = 1.226776314283e-09 
+   Momentum: 
+      |mRes|_2  = 4.975978433881e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 40 markers in 8.3311e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 23 =================================
+--------------------------------------------------------------------------
+Current time        : 0.24849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.598199297591e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.289551649936e-03 
+  1 PICARD ||F||/||F0||=1.954399e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 6.391135575114e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0100732 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.490146814970e-09 
+      |Div|_2   = 2.586443945233e-09 
+   Momentum: 
+      |mRes|_2  = 6.391135575061e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 57 markers in 8.7119e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 24 =================================
+--------------------------------------------------------------------------
+Current time        : 0.27974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.769404319579e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.163267975781e-03 
+  1 PICARD ||F||/||F0||=1.497242e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 3.686489529185e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.00998904 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.763771935456e-10 
+      |Div|_2   = 2.508047192488e-09 
+   Momentum: 
+      |mRes|_2  = 3.686489529099e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 46 markers in 8.4620e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 25 =================================
+--------------------------------------------------------------------------
+Current time        : 0.31099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.458249033151e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 7.415136528521e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00564827 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.066150382661e-09 
+      |Div|_2   = 9.508980067960e-08 
+   Momentum: 
+      |mRes|_2  = 7.415136467550e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 44 markers in 8.2802e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0110568 sec)
+--------------------------------------------------------------------------
+================================ STEP 26 =================================
+--------------------------------------------------------------------------
+Current time        : 0.34224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.906420765738e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.491818080109e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00582434 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.171079410653e-08 
+      |Div|_2   = 9.352632289438e-08 
+   Momentum: 
+      |mRes|_2  = 3.491817954856e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 58 markers in 8.7654e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 27 =================================
+--------------------------------------------------------------------------
+Current time        : 0.37349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.206232021976e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.330258071849e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00568375 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.363851255984e-09 
+      |Div|_2   = 8.528298295468e-08 
+   Momentum: 
+      |mRes|_2  = 6.330258014401e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 54 markers in 8.6558e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 28 =================================
+--------------------------------------------------------------------------
+Current time        : 0.40474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.593805079922e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.545273909600e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00571126 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.388317110755e-09 
+      |Div|_2   = 8.655348674597e-08 
+   Momentum: 
+      |mRes|_2  = 9.545273870358e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 47 markers in 8.4047e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 29 =================================
+--------------------------------------------------------------------------
+Current time        : 0.43599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.041263167192e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.077856788731e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00563264 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.180735127477e-08 
+      |Div|_2   = 8.683870550481e-08 
+   Momentum: 
+      |mRes|_2  = 5.077856714478e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 51 markers in 8.4243e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 30 =================================
+--------------------------------------------------------------------------
+Current time        : 0.46724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.976390619471e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.172707161791e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00567566 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.130978135039e-09 
+      |Div|_2   = 8.192510583927e-08 
+   Momentum: 
+      |mRes|_2  = 4.172707081367e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 57 markers in 8.6029e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0112152 sec)
+--------------------------------------------------------------------------
+================================ STEP 31 =================================
+--------------------------------------------------------------------------
+Current time        : 0.49849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.921426723169e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.454454942998e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00585809 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.383811521315e-09 
+      |Div|_2   = 7.734445953085e-08 
+   Momentum: 
+      |mRes|_2  = 9.454454911361e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 54 markers in 8.5724e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 32 =================================
+--------------------------------------------------------------------------
+Current time        : 0.52974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.865263163640e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.106838995188e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00574881 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.881029428234e-09 
+      |Div|_2   = 7.027576392150e-08 
+   Momentum: 
+      |mRes|_2  = 9.106838968073e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 54 markers in 8.5446e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 33 =================================
+--------------------------------------------------------------------------
+Current time        : 0.56099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.386989881155e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.364419246993e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00574299 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.231260438296e-09 
+      |Div|_2   = 8.552109812349e-08 
+   Momentum: 
+      |mRes|_2  = 5.364419178822e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 51 markers in 8.4649e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 34 =================================
+--------------------------------------------------------------------------
+Current time        : 0.59224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.184477206187e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.197177186813e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00576666 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.829172198822e-09 
+      |Div|_2   = 6.773923295605e-08 
+   Momentum: 
+      |mRes|_2  = 6.197177149791e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 57 markers in 8.5157e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 35 =================================
+--------------------------------------------------------------------------
+Current time        : 0.62349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.621620764807e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.127070367877e-02 
+  1 PICARD ||F||/||F0||=4.102894e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 7.859111337914e-03 
+  2 PICARD ||F||/||F0||=1.031160e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 8.097544844115e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0147942 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.742661944939e-09 
+      |Div|_2   = 1.195311316554e-08 
+   Momentum: 
+      |mRes|_2  = 8.097544843232e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 20 markers in 7.9463e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0111578 sec)
+--------------------------------------------------------------------------
+================================ STEP 36 =================================
+--------------------------------------------------------------------------
+Current time        : 0.65474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.138106088152e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.917409105490e-03 
+  1 PICARD ||F||/||F0||=2.686159e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 9.907942008799e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0103356 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.015782757605e-10 
+      |Div|_2   = 2.695493173937e-09 
+   Momentum: 
+      |mRes|_2  = 9.907942008762e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 33 markers in 8.2759e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 37 =================================
+--------------------------------------------------------------------------
+Current time        : 0.68599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.731388063404e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.389125540942e-03 
+  1 PICARD ||F||/||F0||=3.549232e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 3.446285601206e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0102278 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.985736260631e-10 
+      |Div|_2   = 2.192556655367e-09 
+   Momentum: 
+      |mRes|_2  = 3.446285601136e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 36 markers in 8.3638e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 38 =================================
+--------------------------------------------------------------------------
+Current time        : 0.71724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.643312252933e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.179298971409e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00574089 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.971774531343e-09 
+      |Div|_2   = 8.371315121428e-08 
+   Momentum: 
+      |mRes|_2  = 4.179298887568e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 34 markers in 8.0131e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 39 =================================
+--------------------------------------------------------------------------
+Current time        : 0.74849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.023410395477e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.517157670712e-03 
+  1 PICARD ||F||/||F0||=2.518769e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 7.668852456635e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0102145 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.787158423855e-10 
+      |Div|_2   = 2.948565873432e-09 
+   Momentum: 
+      |mRes|_2  = 7.668852456578e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 36 markers in 8.0433e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 40 =================================
+--------------------------------------------------------------------------
+Current time        : 0.77974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.103846889415e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.428852483048e-03 
+  1 PICARD ||F||/||F0||=3.979216e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.065406245715e-03 
+  2 PICARD ||F||/||F0||=1.745467e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 3.017718598808e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0147057 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.473603766820e-10 
+      |Div|_2   = 8.529119104336e-10 
+   Momentum: 
+      |mRes|_2  = 3.017718598796e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 37 markers in 7.9817e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0109384 sec)
+--------------------------------------------------------------------------
+================================ STEP 41 =================================
+--------------------------------------------------------------------------
+Current time        : 0.81099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.425009704037e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.608579752036e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00584547 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.319862370022e-09 
+      |Div|_2   = 9.388306107813e-08 
+   Momentum: 
+      |mRes|_2  = 4.608579656410e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 40 markers in 8.1889e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 42 =================================
+--------------------------------------------------------------------------
+Current time        : 0.84224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.456884239030e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.144765548729e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00576098 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.427457709616e-09 
+      |Div|_2   = 9.749974663658e-08 
+   Momentum: 
+      |mRes|_2  = 9.144765496753e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 37 markers in 8.3697e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 43 =================================
+--------------------------------------------------------------------------
+Current time        : 0.87349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.497349795071e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.787994296272e-03 
+  1 PICARD ||F||/||F0||=3.718640e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.294928221459e-03 
+  2 PICARD ||F||/||F0||=1.727181e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 4.270042865738e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0146989 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.368438803509e-10 
+      |Div|_2   = 1.297502404597e-09 
+   Momentum: 
+      |mRes|_2  = 4.270042865718e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 44 markers in 8.1553e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 44 =================================
+--------------------------------------------------------------------------
+Current time        : 0.90474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.714800982241e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.725716223242e-03 
+  1 PICARD ||F||/||F0||=2.570018e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 6.188726888742e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0102087 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.218698369838e-10 
+      |Div|_2   = 1.491367124334e-09 
+   Momentum: 
+      |mRes|_2  = 6.188726886945e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 44 markers in 8.2274e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 45 =================================
+--------------------------------------------------------------------------
+Current time        : 0.93599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.948976397844e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.775159441171e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00574161 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.044649915519e-08 
+      |Div|_2   = 1.056439461604e-07 
+   Momentum: 
+      |mRes|_2  = 2.775159240090e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 48 markers in 8.1810e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.01091 sec)
+--------------------------------------------------------------------------
+================================ STEP 46 =================================
+--------------------------------------------------------------------------
+Current time        : 0.96724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.757474796844e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.370747084675e-03 
+  1 PICARD ||F||/||F0||=1.767002e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 6.643705749078e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0103294 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.238039436812e-10 
+      |Div|_2   = 2.407397352831e-09 
+   Momentum: 
+      |mRes|_2  = 6.643705749035e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 41 markers in 8.1257e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 47 =================================
+--------------------------------------------------------------------------
+Current time        : 0.99849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.997922488223e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.359185628708e-03 
+  1 PICARD ||F||/||F0||=2.949748e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 8.092065882380e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0102371 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.488993051255e-10 
+      |Div|_2   = 2.244944752158e-09 
+   Momentum: 
+      |mRes|_2  = 8.092065882349e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 54 markers in 8.2655e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 48 =================================
+--------------------------------------------------------------------------
+Current time        : 1.02974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.897322466406e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.357476618202e-03 
+  1 PICARD ||F||/||F0||=1.718907e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 3.708903562022e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0102085 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.470562261605e-09 
+      |Div|_2   = 5.827945839479e-09 
+   Momentum: 
+      |mRes|_2  = 3.708903561564e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 53 markers in 8.2310e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 49 =================================
+--------------------------------------------------------------------------
+Current time        : 1.06099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.812360286146e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.454140145784e-03 
+  1 PICARD ||F||/||F0||=2.501807e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 9.602889163969e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0101773 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.906286291921e-09 
+      |Div|_2   = 6.031060736380e-09 
+   Momentum: 
+      |mRes|_2  = 9.602889163780e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 53 markers in 8.3476e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 50 =================================
+--------------------------------------------------------------------------
+Current time        : 1.09224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.662058925933e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.703370053743e-03 
+  1 PICARD ||F||/||F0||=2.556822e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 7.827856599786e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0101955 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.581973358768e-09 
+      |Div|_2   = 4.411215304274e-09 
+   Momentum: 
+      |mRes|_2  = 7.827856599662e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 49 markers in 8.2537e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0108077 sec)
+--------------------------------------------------------------------------
+================================ STEP 51 =================================
+--------------------------------------------------------------------------
+Current time        : 1.12349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.446219842175e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.206007029696e-03 
+  1 PICARD ||F||/||F0||=3.422172e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 9.049149030501e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0102056 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.772647378931e-09 
+      |Div|_2   = 7.875556771479e-09 
+   Momentum: 
+      |mRes|_2  = 9.049149030159e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 51 markers in 8.3973e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 52 =================================
+--------------------------------------------------------------------------
+Current time        : 1.15474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.407546507742e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.667056298640e-03 
+  1 PICARD ||F||/||F0||=3.600458e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.465984186542e-03 
+  2 PICARD ||F||/||F0||=1.979041e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 8.168096239370e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0145612 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.038794261332e-10 
+      |Div|_2   = 1.996266950310e-09 
+   Momentum: 
+      |mRes|_2  = 8.168096239346e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 55 markers in 8.5557e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 53 =================================
+--------------------------------------------------------------------------
+Current time        : 1.18599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.613466291899e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.941432239309e-03 
+  1 PICARD ||F||/||F0||=2.935574e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.142405217364e-03 
+  2 PICARD ||F||/||F0||=1.727393e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 6.664449360788e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0145235 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.765108840218e-10 
+      |Div|_2   = 2.041500573713e-09 
+   Momentum: 
+      |mRes|_2  = 6.664449360756e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 57 markers in 8.5747e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 54 =================================
+--------------------------------------------------------------------------
+Current time        : 1.21724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.409170586293e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.312044115630e-03 
+  1 PICARD ||F||/||F0||=6.608174e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 3.454103075394e-03 
+  2 PICARD ||F||/||F0||=2.451160e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 1.508183709947e-03 
+  3 PICARD ||F||/||F0||=1.070263e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  4 SNES Function norm 6.121991364150e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 4
+SNES solution time      : 0.0188927 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.154723820098e-10 
+      |Div|_2   = 1.321496596633e-09 
+   Momentum: 
+      |mRes|_2  = 6.121991364136e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 67 markers in 8.6674e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 55 =================================
+--------------------------------------------------------------------------
+Current time        : 1.24849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.529388273808e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.168596574619e-02 
+  1 PICARD ||F||/||F0||=7.640941e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 6.074010419899e-03 
+  2 PICARD ||F||/||F0||=3.971529e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 2.529418512493e-03 
+  3 PICARD ||F||/||F0||=1.653876e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  4 SNES Function norm 1.332796970376e-03 
+  4 PICARD ||F||/||F0||=8.714576e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  5 SNES Function norm 7.074881900818e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 5
+SNES solution time      : 0.0234061 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.431861296757e-10 
+      |Div|_2   = 1.600348276433e-09 
+   Momentum: 
+      |mRes|_2  = 7.074881900800e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 67 markers in 8.7003e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0108149 sec)
+--------------------------------------------------------------------------
+================================ STEP 56 =================================
+--------------------------------------------------------------------------
+Current time        : 1.27974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.241820898141e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.574328624256e-03 
+  1 PICARD ||F||/||F0||=7.709911e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 4.301924542125e-03 
+  2 PICARD ||F||/||F0||=3.464207e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 2.298198939940e-03 
+  3 PICARD ||F||/||F0||=1.850669e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  4 SNES Function norm 1.118276024433e-03 
+  4 PICARD ||F||/||F0||=9.005131e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  5 SNES Function norm 5.182543291757e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 5
+SNES solution time      : 0.0234912 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.395115456970e-09 
+      |Div|_2   = 2.044508726285e-09 
+   Momentum: 
+      |mRes|_2  = 5.182543291716e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 65 markers in 8.9631e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 57 =================================
+--------------------------------------------------------------------------
+Current time        : 1.31099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.277835399757e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 7.989812562894e-03 
+  1 PICARD ||F||/||F0||=6.252615e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 3.774748858914e-03 
+  2 PICARD ||F||/||F0||=2.954018e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 2.064516835171e-03 
+  3 PICARD ||F||/||F0||=1.615636e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  4 SNES Function norm 1.222026734101e-03 
+  4 PICARD ||F||/||F0||=9.563256e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  5 SNES Function norm 7.438671921714e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 5
+SNES solution time      : 0.0233414 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.409555734193e-10 
+      |Div|_2   = 6.368855999871e-10 
+   Momentum: 
+      |mRes|_2  = 7.438671921711e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 63 markers in 8.7221e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 58 =================================
+--------------------------------------------------------------------------
+Current time        : 1.34224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.380252959636e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.795621525862e-03 
+  1 PICARD ||F||/||F0||=2.433008e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 6.145043274763e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0101363 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.759060106669e-09 
+      |Div|_2   = 5.087784655378e-09 
+   Momentum: 
+      |mRes|_2  = 6.145043274552e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 68 markers in 8.7360e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 59 =================================
+--------------------------------------------------------------------------
+Current time        : 1.37349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.118097119879e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.368712474154e-03 
+  1 PICARD ||F||/||F0||=5.696028e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 3.189051884356e-03 
+  2 PICARD ||F||/||F0||=2.852214e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 1.425931365303e-03 
+  3 PICARD ||F||/||F0||=1.275320e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  4 SNES Function norm 6.185984578863e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 4
+SNES solution time      : 0.0189518 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.134737890272e-09 
+      |Div|_2   = 3.910779427384e-09 
+   Momentum: 
+      |mRes|_2  = 6.185984578740e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 67 markers in 8.8346e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 60 =================================
+--------------------------------------------------------------------------
+Current time        : 1.40474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.213696222653e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.164790362315e-03 
+  1 PICARD ||F||/||F0||=4.255423e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.907298031268e-03 
+  2 PICARD ||F||/||F0||=1.571479e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 9.309783523042e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0145101 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.892289994078e-09 
+      |Div|_2   = 2.995256153855e-09 
+   Momentum: 
+      |mRes|_2  = 9.309783522994e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 63 markers in 8.6701e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0110536 sec)
+--------------------------------------------------------------------------
+================================ STEP 61 =================================
+--------------------------------------------------------------------------
+Current time        : 1.43599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.892333223947e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.803777230391e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00575409 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.968430512181e-08 
+      |Div|_2   = 1.390217128566e-07 
+   Momentum: 
+      |mRes|_2  = 9.803777131822e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 64 markers in 8.7294e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 62 =================================
+--------------------------------------------------------------------------
+Current time        : 1.46724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.051829455380e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.926319758470e-03 
+  1 PICARD ||F||/||F0||=6.585022e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 3.328897571985e-03 
+  2 PICARD ||F||/||F0||=3.164864e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 1.108450215838e-03 
+  3 PICARD ||F||/||F0||=1.053831e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  4 SNES Function norm 3.438612416260e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 4
+SNES solution time      : 0.0187868 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.150242939339e-09 
+      |Div|_2   = 3.631206755032e-09 
+   Momentum: 
+      |mRes|_2  = 3.438612416068e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 57 markers in 8.5321e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 63 =================================
+--------------------------------------------------------------------------
+Current time        : 1.49849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.724082434568e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.927029415932e-03 
+  1 PICARD ||F||/||F0||=2.857769e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.803809839218e-03 
+  2 PICARD ||F||/||F0||=1.046243e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 9.181824838059e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0143947 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.948572467443e-09 
+      |Div|_2   = 2.423872990791e-09 
+   Momentum: 
+      |mRes|_2  = 9.181824838027e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 65 markers in 8.7456e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 64 =================================
+--------------------------------------------------------------------------
+Current time        : 1.52974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.884573859154e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.218031894036e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00565425 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.602708966838e-08 
+      |Div|_2   = 1.308386759204e-07 
+   Momentum: 
+      |mRes|_2  = 9.218031801181e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 61 markers in 8.6166e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 65 =================================
+--------------------------------------------------------------------------
+Current time        : 1.56099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.709932996397e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.470473569922e-03 
+  1 PICARD ||F||/||F0||=1.907246e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 8.553003816926e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0100451 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.132684823431e-09 
+      |Div|_2   = 3.287203152197e-09 
+   Momentum: 
+      |mRes|_2  = 8.553003816863e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 68 markers in 8.8762e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0109047 sec)
+--------------------------------------------------------------------------
+================================ STEP 66 =================================
+--------------------------------------------------------------------------
+Current time        : 1.59224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.858893939334e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.534061099732e-03 
+  1 PICARD ||F||/||F0||=1.952006e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 8.754554006961e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0101154 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.487922793007e-10 
+      |Div|_2   = 2.337048258651e-09 
+   Momentum: 
+      |mRes|_2  = 8.754554006930e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 67 markers in 8.8097e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 67 =================================
+--------------------------------------------------------------------------
+Current time        : 1.62349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.333210432285e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.831195166695e-03 
+  1 PICARD ||F||/||F0||=2.497126e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 1.130812743208e-03 
+  2 PICARD ||F||/||F0||=1.542043e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 6.554490428133e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.014427 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.953256987856e-10 
+      |Div|_2   = 1.089465600352e-09 
+   Momentum: 
+      |mRes|_2  = 6.554490428124e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 63 markers in 8.6491e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 68 =================================
+--------------------------------------------------------------------------
+Current time        : 1.65474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.147367139576e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.086047538519e-03 
+  1 PICARD ||F||/||F0||=1.519507e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 5.353793223034e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0100225 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.696767220350e-10 
+      |Div|_2   = 1.843360606194e-09 
+   Momentum: 
+      |mRes|_2  = 5.353793223002e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 62 markers in 8.5735e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 69 =================================
+--------------------------------------------------------------------------
+Current time        : 1.68599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.253612917760e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.257225872252e-03 
+  1 PICARD ||F||/||F0||=1.733241e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 6.202518961413e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.010007 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.585924833108e-10 
+      |Div|_2   = 2.190025770781e-09 
+   Momentum: 
+      |mRes|_2  = 6.202518961374e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 68 markers in 8.7737e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 70 =================================
+--------------------------------------------------------------------------
+Current time        : 1.71724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.485612455711e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.101009623959e-03 
+  1 PICARD ||F||/||F0||=1.697619e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 5.639200250104e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0100036 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.452395093046e-10 
+      |Div|_2   = 2.228129096655e-09 
+   Momentum: 
+      |mRes|_2  = 5.639200250060e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 72 markers in 8.8806e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0109561 sec)
+--------------------------------------------------------------------------
+=========================== SOLUTION IS DONE! ============================
+--------------------------------------------------------------------------
+Total solution time : 1.44966 (sec) 
+--------------------------------------------------------------------------

--- a/test/t32_BC_velocity/BC_velocity_2D_LR.dat
+++ b/test/t32_BC_velocity/BC_velocity_2D_LR.dat
@@ -1,0 +1,297 @@
+# This is an example of variable inflow velocity from left boundary with prescribed time intervals for each stage
+# The model has a viscoelastoplastic rheology and the geometry is created with the build-in 
+# geometry objects. We use a multigrid solver
+
+#===============================================================================
+# Scaling
+#===============================================================================
+
+	units            = geo		# geological units 
+	
+	unit_temperature = 1000
+	unit_length      = 1e3
+	unit_viscosity   = 1e19
+	unit_stress      = 1e9
+	
+#===============================================================================
+# Time stepping parameters
+#===============================================================================
+
+	time_end  = 100     # simulation end time
+	dt        = 0.001   # initial time step
+	dt_min    = 1e-5    # minimum time step (declare divergence if lower value is attempted)
+	dt_max    = 0.1   	# maximum time step
+	inc_dt    = 0.2     # time step increment per time step (fraction of unit)
+	CFL       = 0.5     # CFL (Courant-Friedrichs-Lewy) criterion
+	CFLMAX    = 1.0     # CFL criterion for elasticity
+	nstep_max = 70      # maximum allowed number of steps (lower bound: time_end/dt_max)
+	nstep_out = 5       # save output every n steps
+	nstep_rdb = 100     # save restart database every n steps
+
+
+#===============================================================================
+# Grid & discretization parameters
+#===============================================================================
+
+# Number of cells for all segments
+	nel_x = 32
+	nel_y = 1
+	nel_z = 16
+
+# Coordinates of all segments (including start and end points)
+
+	coord_x = -100  100
+	coord_y = -2.5  2.5
+	coord_z = -100  100
+
+#===============================================================================
+# Free surface
+#===============================================================================
+	surf_use           = 1                # free surface activation flag
+	surf_corr_phase    = 1                # air phase ratio correction flag (due to surface position)
+	surf_level         = 0                # initial level
+	surf_air_phase     = 0                # phase ID of sticky air layer
+	surf_max_angle     = 45.0             # maximum angle with horizon (smoothed if larger)
+	
+#===============================================================================
+# Boundary conditions
+#===============================================================================
+	open_top_bound = 1
+
+	# Velocity boundary condition
+
+	bvel_face               = Right             # # Face identifier  (Left; Right; Front; Back; CompensatingInflow)
+    bvel_face_out           = 1
+	bvel_bot                = -30               # bottom coordinate of inflow window
+	bvel_top                = 0                 # top coordinate of inflow window
+    velin_num_periods       = 3                 # number of intervals for inflow velocity
+	velin_time_delims       =    0.1   0.6      # time delimiters (one less than number of intervals, not required for one interval)
+	bvel_velin              = 10    -10   10    # strain rates for each interval
+	bvel_relax_d            = 10
+
+
+# temperature on the top & bottom boundaries
+
+	temp_top  = 0.0
+	temp_bot  = 1300.0
+
+#===============================================================================
+# Solution parameters & controls
+#===============================================================================
+
+	gravity        = 0.0 0.0 -9.81  # gravity vector
+	FSSA           = 1.0            # free surface stabilization parameter [0 - 1]
+	init_guess     = 1              # initial guess flag
+	p_lim_plast    = 1              # limit pressure at first iteration for plasticity
+#	p_litho_visc   = 1              # use lithostatic pressure for creep laws
+	p_litho_plast  = 1              # use lithostatic pressure for plasticity
+	eta_min        = 1e19           # viscosity upper bound
+	eta_max        = 1e25           # viscosity lower limit
+	eta_ref        = 1e22           # reference viscosity (initial guess)
+	min_cohes      = 1e6            # cohesion lower bound
+	min_fric       = 1.0            # friction lower bound
+	tau_ult        = 1e9            # ultimate yield stress
+
+	
+#===============================================================================
+# Solver options
+#===============================================================================
+	SolverType 		=	multigrid 			# solver [direct or multigrid]
+	DirectSolver 	=	mumps			# mumps/superlu_dist/pastix	
+	DirectPenalty 	=	1e5
+		
+#===============================================================================
+# Model setup & advection
+#===============================================================================
+
+	msetup         = geom              # setup type
+	nmark_x        = 3                 # markers per cell in x-direction
+	nmark_y        = 3                 # ...                 y-direction
+	nmark_z        = 3                 # ...                 z-direction
+	bg_phase       = 0                 # background phase ID
+	rand_noise     = 1                 # random noise flag
+	advect         = rk2               # advection scheme
+	interp         = minmod             # velocity interpolation scheme
+	mark_ctrl      = basic             # marker control type
+	nmark_lim      = 8 100            # min/max number per cell
+	
+
+# Geometric primitives:
+	
+	# sticky air
+	<BoxStart>
+		phase  = 0
+		bounds = -100 100 -2.5 2.5 0 100  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+	
+	# Asthenosphere
+	<BoxStart>
+		phase  = 1
+		bounds = -100 100 -2.5 2.5 -100 0  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+	
+	# Lithosphere left
+	<BoxStart>
+		phase  = 2
+		bounds = -100 -20 -2.5 2.5 -30 0  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+
+	# lithosphere right
+	<BoxStart>
+		phase  = 2
+		bounds = 20 100 -2.5 2.5 -30 0  # (left, right, front, back, bottom, top)
+	<BoxEnd>
+	
+#===============================================================================
+# Output
+#===============================================================================
+
+# Grid output options (output is always active)
+
+	out_file_name       = BC_velocity_LR # output file name
+	out_pvd             = 1       	# activate writing .pvd file
+	out_phase           = 1
+	out_density         = 1
+	out_visc_total      = 1
+	out_visc_creep      = 1
+	out_velocity        = 1
+	out_pressure        = 1
+	out_eff_press       = 1
+	out_temperature     = 1
+	out_dev_stress      = 1
+	out_j2_dev_stress   = 1
+	out_strain_rate     = 1
+	out_j2_strain_rate  = 1
+	out_yield           = 1
+	out_plast_strain    = 1
+	out_plast_dissip    = 1
+	out_tot_displ       = 1
+	out_moment_res      = 1
+	out_cont_res        = 1
+	
+# AVD phase viewer output options (requires activation)
+
+	out_avd     		= 1 # activate AVD phase output
+	out_avd_pvd 		= 1 # activate writing .pvd file
+	out_avd_ref 		= 3 # AVD grid refinement factor
+	
+# Free surface output options (can be activated only if surface tracking is enabled)
+
+	out_surf            = 1 # activate surface output
+	out_surf_pvd        = 1 # activate writing .pvd file
+	out_surf_velocity   = 1
+	out_surf_topography = 1
+	out_surf_amplitude  = 1
+	
+#===============================================================================
+# Material phase parameters
+#===============================================================================
+	# Strain softening parameters
+	<SofteningStart>
+		ID   = 0
+		A    = 0.87		# reduction ratio = 1-FinalParameter/InitialParameter
+		APS1 = 0.5
+		APS2 = 1.5
+	<SofteningEnd>
+	
+	# Sticky Air
+	<MaterialStart>
+		ID  = 0 	# phase id
+		rho = 0 	# density
+		G   = 5e10
+		eta = 1e18 	# viscosity
+		
+		ch  		=  20e6	  # Cohesion
+		fr  		=  15	  # initial friction angle
+	<MaterialEnd>
+
+	# Asthenosphere
+	<MaterialStart>
+		ID  		= 	1       # phase id
+		rho 		= 	3300    # density
+		eta 		= 	1e20    # viscosity
+		G   		= 	5e10
+
+		ch  		=  	20e5	  # Cohesion
+		fr  		=  	15	  # initial friction angle
+		frSoftID   	=  	0     # softening ID
+	<MaterialEnd>
+
+	# Lithosphere
+	<MaterialStart>
+		ID  		= 	2       # phase id
+		rho 		= 	3250    # density
+		eta 		= 	1e21    # viscosity
+		G   		= 	5e10
+		
+		ch  		=  	20e5	  # Cohesion
+		fr  		=  	15	  # initial friction angle
+		frSoftID   	=  	0     # softening ID
+	<MaterialEnd>
+	
+	# Lower Lithosphere
+	<MaterialStart>
+		ID  		= 	3       # phase id
+		rho 		= 	3300    # density
+		eta 		= 	1e20    # viscosity		1e22: symmetric, 1e21: asymmetric
+		G   		= 	5e10
+
+	<MaterialEnd>
+	
+#===============================================================================
+# PETSc options
+#===============================================================================
+
+<PetscOptionsStart>
+
+	# LINEAR & NONLINEAR SOLVER OPTIONS
+	-snes_ksp_ew
+	-snes_ksp_ew_rtolmax 1e-3
+	-snes_rtol 1e-3					
+	-snes_atol 1e-3					# following Le Pourhiet et al. (EPSL, 2017)
+	-snes_max_it 20					
+	
+
+	-snes_PicardSwitchToNewton_rtol 1e-3   # relative tolerance to switch to Newton (1e-2)
+	-snes_NewtonSwitchToPicard_it  	10     # number of Newton iterations after which we switch back to Picard
+
+# Jacobian solver
+
+	-js_ksp_max_it 20
+
+#	-js_ksp_monitor # display how the inner iterations converge
+
+         -da_refine_y 1
+#   -gmg_pc_view
+#   -gmg_dump
+#	-gmg_pc_type mg 
+#	-gmg_pc_mg_levels 2 
+#	-gmg_pc_mg_galerkin
+#	-gmg_pc_mg_type multiplicative
+#	-gmg_pc_mg_cycle_type v
+#
+#	-gmg_mg_levels_ksp_type richardson
+#	-gmg_mg_levels_ksp_richardson_scale 0.5
+#	-gmg_mg_levels_ksp_max_it 5
+#	-gmg_mg_levels_pc_type jacobi
+
+	-gmg_pc_type mg 
+	-gmg_pc_mg_levels 3
+	-gmg_pc_mg_galerkin
+	-gmg_pc_mg_type multiplicative
+	-gmg_pc_mg_cycle_type v
+#
+	-gmg_mg_levels_ksp_type richardson
+	-gmg_mg_levels_ksp_richardson_scale 0.5
+	-gmg_mg_levels_ksp_max_it 4
+	-gmg_mg_levels_pc_type jacobi
+#
+
+
+	-crs_ksp_type preonly
+	-crs_pc_type lu
+	-crs_pc_factor_mat_solver_package superlu_dist
+
+<PetscOptionsEnd>
+
+#===============================================================================

--- a/test/t32_BC_velocity/BC_velocity_2D_LR_opt-p1.expected
+++ b/test/t32_BC_velocity/BC_velocity_2D_LR_opt-p1.expected
@@ -1,0 +1,2112 @@
+-------------------------------------------------------------------------- 
+                   Lithosphere and Mantle Evolution Model                   
+     Compiled: Date: May 17 2023 - Time: 10:57:24 	    
+     Version : 2.1.0 
+-------------------------------------------------------------------------- 
+        STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
+-------------------------------------------------------------------------- 
+Parsing input file : BC_velocity_2D_LR.dat 
+   Adding PETSc option: -snes_ksp_ew
+   Adding PETSc option: -snes_ksp_ew_rtolmax 1e-3
+   Adding PETSc option: -snes_rtol 1e-3
+   Adding PETSc option: -snes_atol 1e-3
+   Adding PETSc option: -snes_max_it 20
+   Adding PETSc option: -snes_PicardSwitchToNewton_rtol 1e-3
+   Adding PETSc option: -snes_NewtonSwitchToPicard_it 10
+   Adding PETSc option: -js_ksp_max_it 20
+   Adding PETSc option: -da_refine_y 1
+   Adding PETSc option: -gmg_pc_type mg
+   Adding PETSc option: -gmg_pc_mg_levels 3
+   Adding PETSc option: -gmg_pc_mg_galerkin
+   Adding PETSc option: -gmg_pc_mg_type multiplicative
+   Adding PETSc option: -gmg_pc_mg_cycle_type v
+   Adding PETSc option: -gmg_mg_levels_ksp_type richardson
+   Adding PETSc option: -gmg_mg_levels_ksp_richardson_scale 0.5
+   Adding PETSc option: -gmg_mg_levels_ksp_max_it 4
+   Adding PETSc option: -gmg_mg_levels_pc_type jacobi
+   Adding PETSc option: -crs_ksp_type preonly
+   Adding PETSc option: -crs_pc_type lu
+   Adding PETSc option: -crs_pc_factor_mat_solver_package superlu_dist
+Finished parsing input file : BC_velocity_2D_LR.dat 
+--------------------------------------------------------------------------
+Scaling parameters:
+   Temperature : 1000. [C/K] 
+   Length      : 1000. [m] 
+   Viscosity   : 1e+19 [Pa*s] 
+   Stress      : 1e+09 [Pa] 
+--------------------------------------------------------------------------
+Time stepping parameters:
+   Simulation end time          : 100. [Myr] 
+   Maximum number of steps      : 70 
+   Time step                    : 0.001 [Myr] 
+   Minimum time step            : 1e-05 [Myr] 
+   Maximum time step            : 0.1 [Myr] 
+   Time step increase factor    : 0.2 
+   CFL criterion                : 0.5 
+   CFLMAX (fixed time steps)    : 1. 
+   Output every [n] steps       : 5 
+   Output [n] initial steps     : 1 
+   Save restart every [n] steps : 100 
+--------------------------------------------------------------------------
+Grid parameters:
+   Total number of cpu                  : 1 
+   Processor grid  [nx, ny, nz]         : [1, 1, 1]
+   Fine grid cells [nx, ny, nz]         : [32, 1, 16]
+   Number of cells                      :  512
+   Number of faces                      :  2096
+   Maximum cell aspect ratio            :  2.50000
+   Lower coordinate bounds [bx, by, bz] : [-100., -2.5, -100.]
+   Upper coordinate bounds [ex, ey, ez] : [100., 2.5, 100.]
+--------------------------------------------------------------------------
+Softening laws: 
+--------------------------------------------------------------------------
+   SoftLaw [0] : A = 0.87, APS1 = 0.5, APS2 = 1.5
+--------------------------------------------------------------------------
+Material parameters: 
+--------------------------------------------------------------------------
+- Melt factor mfc = 0.000000   Phase ID : 0   
+   (elast)  : G = 5e+10 [Pa]  
+   (diff)   : eta = 1e+18 [Pa*s]  Bd = 5e-19 [1/Pa/s]  
+   (plast)  : ch = 2e+07 [Pa]  fr = 15. [deg]  
+
+- Melt factor mfc = 0.000000   Phase ID : 1   
+   (dens)   : rho = 3300. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Vs = 3892.49 [m/s]  
+   (diff)   : eta = 1e+20 [Pa*s]  Bd = 5e-21 [1/Pa/s]  
+   (plast)  : ch = 2e+06 [Pa]  fr = 15. [deg]  frSoftID = 0 
+
+- Melt factor mfc = 0.000000   Phase ID : 2   
+   (dens)   : rho = 3250. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Vs = 3922.32 [m/s]  
+   (diff)   : eta = 1e+21 [Pa*s]  Bd = 5e-22 [1/Pa/s]  
+   (plast)  : ch = 2e+06 [Pa]  fr = 15. [deg]  frSoftID = 0 
+
+- Melt factor mfc = 0.000000   Phase ID : 3   
+   (dens)   : rho = 3300. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Vs = 3892.49 [m/s]  
+   (diff)   : eta = 1e+20 [Pa*s]  Bd = 5e-21 [1/Pa/s]  
+
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Free surface parameters: 
+   Sticky air phase ID       : 0 
+   Initial surface level     : 0. [km] 
+   Erosion model             : none
+   Sedimentation model       : none
+   Correct marker phases     @ 
+   Maximum surface slope     : 45. [deg]
+--------------------------------------------------------------------------
+Boundary condition parameters: 
+   No-slip boundary mask [lt rt ft bk bm tp]  : 0 0 0 0 0 0 
+   Open top boundary                          @ 
+   Top boundary temperature                   : 0. [C] 
+   Bottom boundary temperature                : 1300. [C] 
+   Adding inflow velocity at boundary         @ 
+      Inflow velocity boundary                : Right 
+      Outflow at opposite boundary            @ 
+      Inflow phase from next to boundary      @ 
+      Inflow window [bottom, top]             : [-30.00,0.00] [km] 
+      Inflow velocity                         : 10.00 [cm/yr] 
+      Velocity smoothening distance           : 10.00 [km] 
+      Inflow temperature from closest marker  @ 
+--------------------------------------------------------------------------
+Solution parameters & controls:
+   Gravity [gx, gy, gz]                    : [0., 0., -9.81] [m/s^2] 
+   Surface stabilization (FSSA)            :  1. 
+   Compute initial guess                   @ 
+   Use lithostatic pressure for creep      @ 
+   Use lithostatic pressure for plasticity @ 
+   Limit pressure at first iteration       @ 
+   Minimum viscosity                       : 1e+19 [Pa*s] 
+   Maximum viscosity                       : 1e+25 [Pa*s] 
+   Reference viscosity (initial guess)     : 1e+22 [Pa*s] 
+   Minimum cohesion                        : 1e+06 [Pa] 
+   Minimum friction                        : 1. [deg] 
+   Ultimate yield stress                   : 1e+09 [Pa] 
+   Max. melt fraction (viscosity, density) : 0.15    
+   Rheology iteration number               : 25    
+   Rheology iteration tolerance            : 1e-06    
+   Ground water level type                 : none 
+--------------------------------------------------------------------------
+Advection parameters:
+   Advection scheme              : Runge-Kutta 2-nd order
+   Periodic marker advection     : 0 0 0 
+   Marker setup scheme           : geometric primitives
+   Velocity interpolation scheme : MINMOD (correction + MINMOD)
+   Marker control type           : AVD for cells + corner insertion
+   Markers per cell [nx, ny, nz] : [3, 3, 3] 
+   Marker distribution type      : random noise
+   Background phase ID           : 0 
+--------------------------------------------------------------------------
+Reading geometric primitives ... done (0.00029878 sec)
+--------------------------------------------------------------------------
+Output parameters:
+   Output file name                        : BC_velocity_LR 
+   Write .pvd file                         : yes 
+   Phase                                   @ 
+   Density                                 @ 
+   Total effective viscosity               @ 
+   Creep effective viscosity               @ 
+   Velocity                                @ 
+   Pressure                                @ 
+   Temperature                             @ 
+   Deviatoric stress tensor                @ 
+   Deviatoric stress second invariant      @ 
+   Deviatoric strain rate tensor           @ 
+   Deviatoric strain rate second invariant @ 
+   Yield stress                            @ 
+   Accumulated Plastic Strain (APS)        @ 
+   Plastic dissipation                     @ 
+   Total displacements                     @ 
+   Momentum residual                       @ 
+   Continuity residual                     @ 
+--------------------------------------------------------------------------
+Surface output parameters:
+   Write .pvd file : yes 
+   Velocity        @ 
+   Topography      @ 
+   Amplitude       @ 
+--------------------------------------------------------------------------
+AVD output parameters:
+   Write .pvd file       : yes 
+   AVD refinement factor : 3 
+--------------------------------------------------------------------------
+Preconditioner parameters: 
+   Matrix type                   : monolithic
+   Preconditioner type           : coupled Galerkin geometric multigrid
+   Global coarse grid [nx,ny,nz] : [8, 1, 4]
+   Local coarse grid  [nx,ny,nz] : [8, 1, 4]
+   Number of multigrid levels    :  3
+--------------------------------------------------------------------------
+Solver parameters specified: 
+   Outermost Krylov solver       : gmres 
+   Solver type                   : multigrid 
+   Multigrid refinement in x/z 
+   Multigrid smoother levels KSP : richardson 
+   Multigrid dampening parameter : 0.500000 
+   Multigrid smoother levels PC  : jacobi 
+   Number of smoothening steps   : 4 
+   Coarse level KSP              : preonly 
+   Coarse level PC               : lu 
+   Coarse level solver package   : superlu_dist 
+--------------------------------------------------------------------------
+============================== INITIAL GUESS =============================
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.662630109205e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+** PETSc DEPRECATION WARNING ** : the option -pc_factor_mat_solver_package is deprecated as of version 3.9 and will be removed in a future release. Please use the option -pc_factor_mat_solver_type instead. (Silence this warning with -options_suppress_deprecated_warnings)
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 5
+  1 SNES Function norm 1.907852413299e-02 
+  1 PICARD ||F||/||F0||=7.165293e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  2 SNES Function norm 5.007146364355e-06 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0195484 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.923914647316e-09 
+      |Div|_2   = 4.218819754113e-08 
+   Momentum: 
+      |mRes|_2  = 5.006968630825e-06 
+--------------------------------------------------------------------------
+Saving output ... done (0.009429 sec)
+--------------------------------------------------------------------------
+================================= STEP 1 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00000000 [Myr] 
+Tentative time step : 0.00100000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.082351143692e-01 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 3.839576971778e-03 
+  1 PICARD ||F||/||F0||=9.405308e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 10
+  2 SNES Function norm 5.428326917516e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.018388 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.501242502862e-07 
+      |Div|_2   = 1.763131918040e-06 
+   Momentum: 
+      |mRes|_2  = 5.428298283994e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00100 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 2 markers in 7.4688e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00879721 sec)
+--------------------------------------------------------------------------
+================================= STEP 2 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00100000 [Myr] 
+Tentative time step : 0.00120000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.402301440579e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 1.709772270693e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00933094 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.112235677668e-06 
+      |Div|_2   = 2.658292518373e-06 
+   Momentum: 
+      |mRes|_2  = 1.709565607316e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00120 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 7 markers in 7.6592e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 3 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00220000 [Myr] 
+Tentative time step : 0.00144000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.361797707781e-04 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 1.082904971817e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00953676 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.746689626477e-07 
+      |Div|_2   = 2.530660830500e-06 
+   Momentum: 
+      |mRes|_2  = 1.082609234009e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00144 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 5 markers in 7.5972e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 4 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00364000 [Myr] 
+Tentative time step : 0.00172800 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.346001194230e-04 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 1.027761484545e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00932947 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.565202756523e-06 
+      |Div|_2   = 3.913252340592e-06 
+   Momentum: 
+      |mRes|_2  = 1.027016219311e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00173 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 3 markers in 7.5603e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 5 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00536800 [Myr] 
+Tentative time step : 0.00207360 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.593500763018e-04 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 2.773358368498e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00940716 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.240075872299e-06 
+      |Div|_2   = 5.574091371193e-06 
+   Momentum: 
+      |mRes|_2  = 2.772798151805e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00207 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 7 markers in 7.7029e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00954304 sec)
+--------------------------------------------------------------------------
+================================= STEP 6 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00744160 [Myr] 
+Tentative time step : 0.00248832 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.540160906558e-04 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 1.409155760578e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00939105 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.750842967438e-07 
+      |Div|_2   = 3.011875589319e-06 
+   Momentum: 
+      |mRes|_2  = 1.408833850429e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00249 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 3 markers in 7.6530e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 7 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00992992 [Myr] 
+Tentative time step : 0.00298598 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.444019981334e-04 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 1.239182212736e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00941414 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.065886339362e-06 
+      |Div|_2   = 3.410318237828e-06 
+   Momentum: 
+      |mRes|_2  = 1.238712851839e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00299 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 5 markers in 7.7805e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 8 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01291590 [Myr] 
+Tentative time step : 0.00358318 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.076725874534e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 1.528087288798e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00993018 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.536559591547e-06 
+      |Div|_2   = 5.852438861852e-06 
+   Momentum: 
+      |mRes|_2  = 1.526966161421e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00358 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 9 markers in 7.8561e-04 s 
+--------------------------------------------------------------------------
+================================= STEP 9 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01649908 [Myr] 
+Tentative time step : 0.00429982 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.026759688024e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 9.490448304872e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00978674 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.036960359448e-06 
+      |Div|_2   = 4.655726792221e-06 
+   Momentum: 
+      |mRes|_2  = 9.479021632416e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00430 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 10 markers in 7.8819e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 10 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02079890 [Myr] 
+Tentative time step : 0.00515978 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.068066399566e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 1.026783710313e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0098643 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.342479714098e-07 
+      |Div|_2   = 1.190769536502e-06 
+   Momentum: 
+      |mRes|_2  = 1.026714660728e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00516 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 7 markers in 7.7332e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00984046 sec)
+--------------------------------------------------------------------------
+================================ STEP 11 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02595868 [Myr] 
+Tentative time step : 0.00619174 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.349653124954e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 9.573859211917e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0098464 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.487676082254e-06 
+      |Div|_2   = 3.231638602931e-06 
+   Momentum: 
+      |mRes|_2  = 9.568403489036e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00619 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 9 markers in 7.8605e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 12 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03215042 [Myr] 
+Tentative time step : 0.00743008 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.002262142138e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 6.106059420298e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00988195 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.894295314177e-07 
+      |Div|_2   = 1.474577853235e-06 
+   Momentum: 
+      |mRes|_2  = 6.104278650730e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00743 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 13 markers in 7.9148e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 13 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03958050 [Myr] 
+Tentative time step : 0.00891610 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.621168820623e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 11
+  1 SNES Function norm 7.265994178863e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0108378 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.561425246323e-06 
+      |Div|_2   = 6.429381078625e-06 
+   Momentum: 
+      |mRes|_2  = 7.265709718477e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.00892 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 13 markers in 7.9409e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 14 =================================
+--------------------------------------------------------------------------
+Current time        : 0.04849660 [Myr] 
+Tentative time step : 0.01069932 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.740617545491e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 10
+  1 SNES Function norm 1.917089324610e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0102229 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.193701974006e-07 
+      |Div|_2   = 1.598551214204e-06 
+   Momentum: 
+      |mRes|_2  = 1.917022676427e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01070 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 12 markers in 7.8590e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 15 =================================
+--------------------------------------------------------------------------
+Current time        : 0.05919592 [Myr] 
+Tentative time step : 0.01283918 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.686863573739e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 11
+  1 SNES Function norm 1.008690044958e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0108156 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.920319974595e-07 
+      |Div|_2   = 1.860530664368e-06 
+   Momentum: 
+      |mRes|_2  = 1.008518442748e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01284 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 17 markers in 8.0683e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0101669 sec)
+--------------------------------------------------------------------------
+================================ STEP 16 =================================
+--------------------------------------------------------------------------
+Current time        : 0.07203511 [Myr] 
+Tentative time step : 0.01540702 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.738642066388e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 1.454089548002e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0113294 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.283071837179e-06 
+      |Div|_2   = 3.878783942874e-06 
+   Momentum: 
+      |mRes|_2  = 1.453572123123e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01541 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 29 markers in 8.2696e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 17 =================================
+--------------------------------------------------------------------------
+Current time        : 0.08744213 [Myr] 
+Tentative time step : 0.01848843 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.699598207697e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 2.355647161492e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118303 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.056951784768e-06 
+      |Div|_2   = 2.496010213639e-06 
+   Momentum: 
+      |mRes|_2  = 2.355514920934e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.01849 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 29 markers in 8.2221e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 18 =================================
+--------------------------------------------------------------------------
+Current time        : 0.10593056 [Myr] 
+Tentative time step : 0.02218611 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.782508506605e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 2.549510001859e-02 
+  1 PICARD ||F||/||F0||=3.275949e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  2 SNES Function norm 3.072799539770e-03 
+  2 PICARD ||F||/||F0||=3.948341e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  3 SNES Function norm 5.945953796565e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0281503 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.502381195645e-07 
+      |Div|_2   = 1.524106931749e-06 
+   Momentum: 
+      |mRes|_2  = 5.945934263066e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.02219 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 11 markers in 8.0066e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 19 =================================
+--------------------------------------------------------------------------
+Current time        : 0.12811667 [Myr] 
+Tentative time step : 0.02662333 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.837891652438e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 5.744797275394e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114151 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.252417079900e-05 
+      |Div|_2   = 2.708435720352e-05 
+   Momentum: 
+      |mRes|_2  = 5.738409143208e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.02662 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 15 markers in 7.8894e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 20 =================================
+--------------------------------------------------------------------------
+Current time        : 0.15474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.149099032089e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.182727170361e-03 
+  1 PICARD ||F||/||F0||=3.755764e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 14
+  2 SNES Function norm 4.219213528540e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0229899 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.187633932866e-08 
+      |Div|_2   = 1.421592613009e-07 
+   Momentum: 
+      |mRes|_2  = 4.219213289050e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 32 markers in 8.2275e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00984063 sec)
+--------------------------------------------------------------------------
+================================ STEP 21 =================================
+--------------------------------------------------------------------------
+Current time        : 0.18599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.629263800473e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.148040947260e-03 
+  1 PICARD ||F||/||F0||=3.163289e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  2 SNES Function norm 2.375773013761e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0225398 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.251796922897e-07 
+      |Div|_2   = 2.578363509433e-07 
+   Momentum: 
+      |mRes|_2  = 2.375771614646e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 37 markers in 8.2683e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 22 =================================
+--------------------------------------------------------------------------
+Current time        : 0.21724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.711427601608e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.108412617792e-03 
+  1 PICARD ||F||/||F0||=2.986486e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  2 SNES Function norm 5.148765035465e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0225173 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.102537587784e-07 
+      |Div|_2   = 5.095578932908e-07 
+   Momentum: 
+      |mRes|_2  = 5.148762513993e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 40 markers in 8.2841e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 23 =================================
+--------------------------------------------------------------------------
+Current time        : 0.24849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.975005944703e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.634561503903e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118468 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.648781840490e-06 
+      |Div|_2   = 4.265586104442e-06 
+   Momentum: 
+      |mRes|_2  = 1.634004830948e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 38 markers in 8.3448e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 24 =================================
+--------------------------------------------------------------------------
+Current time        : 0.27974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.721148074312e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 2.632739754179e-03 
+  1 PICARD ||F||/||F0||=7.075074e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  2 SNES Function norm 1.111936887291e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0205525 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.498301211756e-07 
+      |Div|_2   = 3.875382462880e-07 
+   Momentum: 
+      |mRes|_2  = 1.111930133924e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 36 markers in 8.2763e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 25 =================================
+--------------------------------------------------------------------------
+Current time        : 0.31099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.184291035429e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.914355873525e-03 
+  1 PICARD ||F||/||F0||=6.011875e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  2 SNES Function norm 4.814819076771e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0225039 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.951292035839e-07 
+      |Div|_2   = 6.131424428785e-07 
+   Momentum: 
+      |mRes|_2  = 4.814815172743e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 51 markers in 8.6819e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0101588 sec)
+--------------------------------------------------------------------------
+================================ STEP 26 =================================
+--------------------------------------------------------------------------
+Current time        : 0.34224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.338363787335e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.251191332613e-03 
+  1 PICARD ||F||/||F0||=3.747918e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 14
+  2 SNES Function norm 1.720517136960e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0230682 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.256666401999e-07 
+      |Div|_2   = 2.166401507079e-07 
+   Momentum: 
+      |mRes|_2  = 1.720515773040e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 39 markers in 8.3419e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 27 =================================
+--------------------------------------------------------------------------
+Current time        : 0.37349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.980162663999e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 9.442150932478e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118448 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.531154284457e-06 
+      |Div|_2   = 6.078438227527e-06 
+   Momentum: 
+      |mRes|_2  = 9.441955278996e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 38 markers in 8.3855e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 28 =================================
+--------------------------------------------------------------------------
+Current time        : 0.40474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.500050096897e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.232096580812e-03 
+  1 PICARD ||F||/||F0||=3.520226e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  2 SNES Function norm 3.869625742216e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0220123 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.974431428092e-07 
+      |Div|_2   = 6.179526130453e-07 
+   Momentum: 
+      |mRes|_2  = 3.869620808074e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 48 markers in 8.9535e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 29 =================================
+--------------------------------------------------------------------------
+Current time        : 0.43599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.773275090293e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 9.337188788289e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0119026 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.195429207934e-06 
+      |Div|_2   = 2.592402379350e-06 
+   Momentum: 
+      |mRes|_2  = 9.337152800139e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 41 markers in 8.6050e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 30 =================================
+--------------------------------------------------------------------------
+Current time        : 0.46724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.620029884522e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 8.129184864667e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0113729 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.340804875358e-05 
+      |Div|_2   = 2.645463366025e-05 
+   Momentum: 
+      |mRes|_2  = 8.124879186776e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 46 markers in 8.5401e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0101433 sec)
+--------------------------------------------------------------------------
+================================ STEP 31 =================================
+--------------------------------------------------------------------------
+Current time        : 0.49849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.440474545632e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 6.041350823559e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114243 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.525605971456e-06 
+      |Div|_2   = 1.488819421131e-05 
+   Momentum: 
+      |mRes|_2  = 6.039516035298e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 52 markers in 8.7326e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 32 =================================
+--------------------------------------------------------------------------
+Current time        : 0.52974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.611059197648e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 4.650680566945e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114003 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.518940883614e-05 
+      |Div|_2   = 2.530125015902e-05 
+   Momentum: 
+      |mRes|_2  = 4.643793105835e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 44 markers in 8.4304e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 33 =================================
+--------------------------------------------------------------------------
+Current time        : 0.56099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.859591278942e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 6.442549102457e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114107 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.780642701258e-06 
+      |Div|_2   = 5.205225782196e-06 
+   Momentum: 
+      |mRes|_2  = 6.442338822200e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 60 markers in 8.6728e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 34 =================================
+--------------------------------------------------------------------------
+Current time        : 0.59224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.105974765732e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 3.792059530286e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.011867 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.985224817129e-06 
+      |Div|_2   = 4.333810606482e-06 
+   Momentum: 
+      |mRes|_2  = 3.791811874262e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 49 markers in 8.5441e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 35 =================================
+--------------------------------------------------------------------------
+Current time        : 0.62349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.906267600136e-02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 8
+  1 SNES Function norm 2.793541376322e-02 
+  1 PICARD ||F||/||F0||=4.044936e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  2 SNES Function norm 2.690762015936e-03 
+  2 PICARD ||F||/||F0||=3.896116e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  3 SNES Function norm 5.037282530132e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 3
+SNES solution time      : 0.0284856 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.009598483060e-07 
+      |Div|_2   = 9.227579854890e-07 
+   Momentum: 
+      |mRes|_2  = 5.037274078323e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 19 markers in 8.2072e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0100932 sec)
+--------------------------------------------------------------------------
+================================ STEP 36 =================================
+--------------------------------------------------------------------------
+Current time        : 0.65474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.335693525404e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 3.305785824378e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114296 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.679739111621e-06 
+      |Div|_2   = 1.825598361720e-05 
+   Momentum: 
+      |mRes|_2  = 3.300741102067e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 26 markers in 8.2518e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 37 =================================
+--------------------------------------------------------------------------
+Current time        : 0.68599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.837289493712e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 2.517054783991e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118181 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.454012765500e-06 
+      |Div|_2   = 5.296507777775e-06 
+   Momentum: 
+      |mRes|_2  = 2.516497463966e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 37 markers in 8.3565e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 38 =================================
+--------------------------------------------------------------------------
+Current time        : 0.71724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.563488838945e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 2.294131213213e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118327 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.454411842799e-06 
+      |Div|_2   = 6.496445264719e-06 
+   Momentum: 
+      |mRes|_2  = 2.293211207745e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 30 markers in 8.2590e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 39 =================================
+--------------------------------------------------------------------------
+Current time        : 0.74849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.828900762336e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.250998594383e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118109 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.984338901864e-06 
+      |Div|_2   = 7.106755824552e-06 
+   Momentum: 
+      |mRes|_2  = 1.248978336606e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 38 markers in 8.2360e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 40 =================================
+--------------------------------------------------------------------------
+Current time        : 0.77974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.846687068876e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 1.467575936430e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00990562 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.796252148124e-06 
+      |Div|_2   = 5.894064217891e-06 
+   Momentum: 
+      |mRes|_2  = 1.466391874598e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 38 markers in 8.2859e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0100897 sec)
+--------------------------------------------------------------------------
+================================ STEP 41 =================================
+--------------------------------------------------------------------------
+Current time        : 0.81099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.884043953493e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 9.996768799549e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118924 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.238915888644e-06 
+      |Div|_2   = 7.565608032666e-06 
+   Momentum: 
+      |mRes|_2  = 9.968099226162e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 36 markers in 8.2313e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 42 =================================
+--------------------------------------------------------------------------
+Current time        : 0.84224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.364069890632e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 2.635474828725e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118762 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.150918149046e-06 
+      |Div|_2   = 4.512308839400e-06 
+   Momentum: 
+      |mRes|_2  = 2.635088514593e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 36 markers in 8.2172e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 43 =================================
+--------------------------------------------------------------------------
+Current time        : 0.87349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.139677911888e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.977210142152e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118776 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.383144908953e-06 
+      |Div|_2   = 2.619969965259e-06 
+   Momentum: 
+      |mRes|_2  = 1.977036550488e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 43 markers in 8.3864e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 44 =================================
+--------------------------------------------------------------------------
+Current time        : 0.90474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.963706787046e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 14
+  1 SNES Function norm 1.041623037810e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0123257 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.811385237547e-07 
+      |Div|_2   = 1.631844900733e-06 
+   Momentum: 
+      |mRes|_2  = 1.041495204558e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 38 markers in 8.4324e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 45 =================================
+--------------------------------------------------------------------------
+Current time        : 0.93599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.227875711643e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 3.593379683010e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118921 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.768728266103e-06 
+      |Div|_2   = 6.285983738726e-06 
+   Momentum: 
+      |mRes|_2  = 3.592829829968e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 39 markers in 8.3431e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0100819 sec)
+--------------------------------------------------------------------------
+================================ STEP 46 =================================
+--------------------------------------------------------------------------
+Current time        : 0.96724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.765127281552e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 2.830791081925e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0119337 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.708787488419e-06 
+      |Div|_2   = 6.299704967602e-06 
+   Momentum: 
+      |mRes|_2  = 2.830090019988e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 38 markers in 8.1066e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 47 =================================
+--------------------------------------------------------------------------
+Current time        : 0.99849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.603533805929e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 8.296375083957e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118835 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.590172910729e-06 
+      |Div|_2   = 5.985158248453e-06 
+   Momentum: 
+      |mRes|_2  = 8.296159190962e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 39 markers in 8.1121e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 48 =================================
+--------------------------------------------------------------------------
+Current time        : 1.02974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.493882519785e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 4.195043918095e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118931 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.467750182427e-06 
+      |Div|_2   = 3.381365749441e-06 
+   Momentum: 
+      |mRes|_2  = 4.194907640379e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 37 markers in 8.1386e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 49 =================================
+--------------------------------------------------------------------------
+Current time        : 1.06099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.265281129100e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 5.051413014051e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118566 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.453719247844e-06 
+      |Div|_2   = 4.683754333458e-06 
+   Momentum: 
+      |mRes|_2  = 5.051195866630e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 44 markers in 8.3974e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 50 =================================
+--------------------------------------------------------------------------
+Current time        : 1.09224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.011137489077e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 3.486673365501e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.011836 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.715639488843e-06 
+      |Div|_2   = 3.315555316986e-06 
+   Momentum: 
+      |mRes|_2  = 3.486515720170e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 43 markers in 8.2476e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0100484 sec)
+--------------------------------------------------------------------------
+================================ STEP 51 =================================
+--------------------------------------------------------------------------
+Current time        : 1.12349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.025811908014e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.391752005932e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118672 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.969403102196e-06 
+      |Div|_2   = 3.369065763778e-06 
+   Momentum: 
+      |mRes|_2  = 1.391344165045e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 49 markers in 8.5735e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 52 =================================
+--------------------------------------------------------------------------
+Current time        : 1.15474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.169548054806e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 7.792901416560e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00998246 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.831861375032e-06 
+      |Div|_2   = 4.561499803584e-06 
+   Momentum: 
+      |mRes|_2  = 7.792767913917e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 48 markers in 8.3648e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 53 =================================
+--------------------------------------------------------------------------
+Current time        : 1.18599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.551110475389e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 11
+  1 SNES Function norm 6.538013149850e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0109611 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.012504274212e-06 
+      |Div|_2   = 2.182395678485e-06 
+   Momentum: 
+      |mRes|_2  = 6.537976725450e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 47 markers in 8.3210e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 54 =================================
+--------------------------------------------------------------------------
+Current time        : 1.21724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.898433933912e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 7.327811170880e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114158 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.287375410480e-06 
+      |Div|_2   = 2.064639362994e-06 
+   Momentum: 
+      |mRes|_2  = 7.327782084812e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 52 markers in 8.6948e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 55 =================================
+--------------------------------------------------------------------------
+Current time        : 1.24849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.740852240799e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 9
+  1 SNES Function norm 4.086199617162e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.00997093 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.320876329582e-06 
+      |Div|_2   = 2.455288028895e-06 
+   Momentum: 
+      |mRes|_2  = 4.086125850651e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 41 markers in 8.2592e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0100794 sec)
+--------------------------------------------------------------------------
+================================ STEP 56 =================================
+--------------------------------------------------------------------------
+Current time        : 1.27974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.429126218518e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 1.129028687610e-03 
+  1 PICARD ||F||/||F0||=3.292468e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  2 SNES Function norm 3.286645010450e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.022593 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.339040425979e-07 
+      |Div|_2   = 6.325746421103e-07 
+   Momentum: 
+      |mRes|_2  = 3.286638922919e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 45 markers in 8.3501e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 57 =================================
+--------------------------------------------------------------------------
+Current time        : 1.31099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.905353032095e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 4.967015232978e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118847 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.091281492162e-06 
+      |Div|_2   = 2.028735447231e-06 
+   Momentum: 
+      |mRes|_2  = 4.966973801812e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 45 markers in 8.2936e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 58 =================================
+--------------------------------------------------------------------------
+Current time        : 1.34224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.454980855707e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 11
+  1 SNES Function norm 8.526777982338e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0108965 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.756356098598e-07 
+      |Div|_2   = 3.108495703334e-06 
+   Momentum: 
+      |mRes|_2  = 8.526721320973e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 52 markers in 8.4510e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 59 =================================
+--------------------------------------------------------------------------
+Current time        : 1.37349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.366244225331e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 3.002236153988e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118594 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.099608212970e-06 
+      |Div|_2   = 4.502147278190e-06 
+   Momentum: 
+      |mRes|_2  = 3.001898564459e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 55 markers in 8.6567e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 60 =================================
+--------------------------------------------------------------------------
+Current time        : 1.40474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.318751453882e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 2.192988158339e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118851 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.329159749679e-06 
+      |Div|_2   = 2.490573233865e-06 
+   Momentum: 
+      |mRes|_2  = 2.192846726771e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 47 markers in 8.2528e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.0100323 sec)
+--------------------------------------------------------------------------
+================================ STEP 61 =================================
+--------------------------------------------------------------------------
+Current time        : 1.43599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.408975661076e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 3.115784022500e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0119132 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.098670385702e-06 
+      |Div|_2   = 2.758696357365e-06 
+   Momentum: 
+      |mRes|_2  = 3.115661893452e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 49 markers in 8.3246e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 62 =================================
+--------------------------------------------------------------------------
+Current time        : 1.46724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.265754165159e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 3.640498593100e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0113997 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.881757561203e-06 
+      |Div|_2   = 3.394085945631e-06 
+   Momentum: 
+      |mRes|_2  = 3.640340372056e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 52 markers in 8.7343e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 63 =================================
+--------------------------------------------------------------------------
+Current time        : 1.49849000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.992296825194e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 4.188867296423e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118929 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.380042070055e-06 
+      |Div|_2   = 2.759505063808e-06 
+   Momentum: 
+      |mRes|_2  = 4.188776401317e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 52 markers in 8.3963e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 64 =================================
+--------------------------------------------------------------------------
+Current time        : 1.52974000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.633285397436e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 13
+  1 SNES Function norm 6.120508417077e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0118779 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.046607721358e-06 
+      |Div|_2   = 4.357435777707e-06 
+   Momentum: 
+      |mRes|_2  = 6.120353303434e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 44 markers in 8.2352e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 65 =================================
+--------------------------------------------------------------------------
+Current time        : 1.56099000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.074516143645e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 5.361818852681e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0113496 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.308874993624e-06 
+      |Div|_2   = 9.163792307242e-06 
+   Momentum: 
+      |mRes|_2  = 5.361035711504e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 50 markers in 8.4083e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00998649 sec)
+--------------------------------------------------------------------------
+================================ STEP 66 =================================
+--------------------------------------------------------------------------
+Current time        : 1.59224000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.637988133929e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 1.749380631254e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114625 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.082434653893e-06 
+      |Div|_2   = 4.598453565845e-06 
+   Momentum: 
+      |mRes|_2  = 1.748776147907e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 55 markers in 8.5636e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 67 =================================
+--------------------------------------------------------------------------
+Current time        : 1.62349000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.332724052862e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 3.525823353757e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0113742 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.600929088207e-06 
+      |Div|_2   = 2.763792256137e-06 
+   Momentum: 
+      |mRes|_2  = 3.525715029201e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 58 markers in 8.5535e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 68 =================================
+--------------------------------------------------------------------------
+Current time        : 1.65474000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.982650138216e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 9.308260752441e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0113926 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.209431721838e-06 
+      |Div|_2   = 2.240637138578e-06 
+   Momentum: 
+      |mRes|_2  = 9.308233784664e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 56 markers in 8.5165e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 69 =================================
+--------------------------------------------------------------------------
+Current time        : 1.68599000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.809757501089e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 7.871571959347e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.0114213 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.270789398403e-06 
+      |Div|_2   = 4.822794805148e-06 
+   Momentum: 
+      |mRes|_2  = 7.871424215236e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 58 markers in 8.6206e-04 s 
+--------------------------------------------------------------------------
+================================ STEP 70 =================================
+--------------------------------------------------------------------------
+Current time        : 1.71724000 [Myr] 
+Tentative time step : 0.03125000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.269927954493e-03 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 12
+  1 SNES Function norm 1.467431831467e-03 
+  1 PICARD ||F||/||F0||=3.436666e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 11
+  2 SNES Function norm 4.741752491465e-04 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.0211456 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.288284027128e-07 
+      |Div|_2   = 2.402393017262e-07 
+   Momentum: 
+      |mRes|_2  = 4.741751882883e-04 
+--------------------------------------------------------------------------
+Actual time step : 0.03125 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (standard algorithm)
+Marker control [0]: (Corners ) injected 60 markers in 8.8491e-04 s 
+--------------------------------------------------------------------------
+Saving output ... done (0.00998381 sec)
+--------------------------------------------------------------------------
+=========================== SOLUTION IS DONE! ============================
+--------------------------------------------------------------------------
+Total solution time : 1.65085 (sec) 
+--------------------------------------------------------------------------


### PR DESCRIPTION
- new feature: changing inflow boundary - it can change inflow velocity in a given time.

I rewrote reading from dat file - now _bvel_velin_ can be an array and it writes to a different array. In time which is given in a different array(velin_time_delims) it takes corresponding velocity and assigns it as bc.velin. The same function calculates bc.velout as before. It is all similar to function BCGetBGStrainRates. I also added separate folder in tests with example how it can be used. This function doesnt change any workflow in usual models with only one velocity.
- To use it specify **_velin_num_periods_** (INT) for a numbers of changing periods
- **_velin_time_delims_** (ARRAY) in Ma for an age when to change for a next period (one less than period number!)
- **_bvel_velin (ARRAY)_** velocities for specified period

- With changing **_face_out_** parameter to -1, 0 or 1 it is possible to change the behaviour of opposite boundary

-"-1" can move the same way (e.g. compress from both sides or pull from both sides),
-"0" don 't move opposite direction (as before)
-"1" move the same direction (as before)

lamem_input file also has been updated